### PR TITLE
Drop transaction queries

### DIFF
--- a/dbt/adapters/trino/connections.py
+++ b/dbt/adapters/trino/connections.py
@@ -72,13 +72,13 @@ class ConnectionWrapper(object):
         self.handle.close()
 
     def commit(self):
-        self.handle.commit()
+        pass
 
     def rollback(self):
-        self.handle.rollback()
+        pass
 
     def start_transaction(self):
-        self.handle.start_transaction()
+        pass
 
     def fetchall(self):
         if self._cursor is None:
@@ -144,15 +144,14 @@ class TrinoConnectionManager(SQLConnectionManager):
             logger.debug(exc)
             raise dbt.exceptions.RuntimeException(str(exc))
 
+    # For connection in auto-commit mode there is no need to start
+    # separate transaction. If using auto-commit, the client will
+    # create a new transaction and commit/rollback for each query
     def add_begin_query(self):
-        connection = self.get_thread_connection()
-        with self.exception_handler("handle.start_transaction()"):
-            connection.handle.start_transaction()
+        pass
 
     def add_commit_query(self):
-        connection = self.get_thread_connection()
-        with self.exception_handler("handle.commit()"):
-            connection.handle.commit()
+        pass
 
     @classmethod
     def open(cls, connection):


### PR DESCRIPTION
dbt-trino adapter uses connection in auto-commit mode, hence there is no need to separately start a new transaction in each query since it makes no effect. In auto-commit mode, the client will create a new transaction for each query. 

That would resolve timeout issue reported here: https://github.com/starburstdata/dbt-trino/issues/20