### PR TITLE
Update incremental.sql

### DIFF
--- a/dbt/include/trino/macros/materializations/incremental.sql
+++ b/dbt/include/trino/macros/materializations/incremental.sql
@@ -1,8 +1,8 @@
 {% macro dbt_trino_get_append_sql(tmp_relation, target_relation) %}
 
-    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
+    {%- set dest_columns = adapter.get_columns_in_relation(tmp_relation) -%}
     {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
-    insert into {{ target_relation }}
+    insert into {{ target_relation }} ({{ dest_cols_csv }})
     select {{dest_cols_csv}} from {{ tmp_relation.include(database=true, schema=true) }};
 
     drop table if exists {{ tmp_relation }};


### PR DESCRIPTION
Columns for incremental insert retrieved from tmp_relation rather than target_relation. Insert statement now contains column listing to match any partial column listing inserts

## Overview
<!---
dbt_trino_get_append_sql amended to allow for partial column listing inserts when using incremental models
-->

- Description:
- Related issue(s): [#48](https://github.com/starburstdata/dbt-trino/issues/48)
## Checklist
- [x] `CHANGELOG.md` updated and added information about my change
