### PR TITLE
Use native prepared statements from trino-python-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add support for `on_table_exists` in table materialization ([#26](https://github.com/starburstdata/dbt-trino/issues/26), [#54](https://github.com/starburstdata/dbt-trino/pull/54))
 - Adds support for OAuth2 authentication using web browser ([#40](https://github.com/starburstdata/dbt-trino/issues/40), [#41](https://github.com/starburstdata/dbt-trino/pull/41))
 - Add `view_security` to define security mode for views ([#65](https://github.com/starburstdata/dbt-trino/pull/65))
+- Support for dbt source freshness ([#28](https://github.com/starburstdata/dbt-trino/issues/28), [#61](https://github.com/starburstdata/dbt-trino/pull/61))
 
 ### Fixes
 - Add support for future versions of dbt-core ([#55](https://github.com/starburstdata/dbt-trino/issues/55), [#65](https://github.com/starburstdata/dbt-trino/pull/65))
@@ -11,11 +12,12 @@
 ### Under the hood
 - Add PostgreSQL docker container for testing ([#66](https://github.com/starburstdata/dbt-trino/issues/66), [#67](https://github.com/starburstdata/dbt-trino/pull/67))
 - Migrate to new adapter testing framework ([#57](https://github.com/starburstdata/dbt-trino/issues/57), [#65](https://github.com/starburstdata/dbt-trino/pull/65))
-
+- Implement trino-python-client's prepared statements using `experimental_python_types` ([#61](https://github.com/starburstdata/dbt-trino/pull/61))
+  
 Contributors:
 * [@hovaesco](https://github.com/hovaesco) ([#54](https://github.com/starburstdata/dbt-trino/pull/54), [#65](https://github.com/starburstdata/dbt-trino/pull/65), [#67](https://github.com/starburstdata/dbt-trino/pull/67))
 * [@smith-m](https://github.com/smith-m) ([#65](https://github.com/starburstdata/dbt-trino/pull/65))
-* [@mdesmet](https://github.com/mdesmet) ([#41](https://github.com/starburstdata/dbt-trino/pull/41))
+* [@mdesmet](https://github.com/mdesmet) ([#41](https://github.com/starburstdata/dbt-trino/pull/41), [#61](https://github.com/starburstdata/dbt-trino/pull/61))
 
 ## dbt-trino 1.0.3 (March 2, 2022)
 

--- a/dbt/include/trino/macros/adapters.sql
+++ b/dbt/include/trino/macros/adapters.sql
@@ -180,3 +180,11 @@
 {% macro trino__current_timestamp() -%}
     CURRENT_TIMESTAMP
 {%- endmacro %}
+
+{% macro trino__get_binding_char() %}
+  {%- if target.prepared_statements_enabled|as_bool -%}
+    {{ return('?') }}
+  {%- else -%}
+    {{ return('%s') }}
+  {%- endif -%}
+{% endmacro %}

--- a/dbt/include/trino/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/trino/macros/materializations/seeds/helpers.sql
@@ -34,7 +34,7 @@
           ('test','abc',CHAR 'd',CHAR 'ghi',VARBINARY '65683F',JSON '{"k1":1,"k2":23,"k3":456}'),(NULL,NULL,NULL,NULL,NULL,NULL)
   
   Usually seed row's values through agate_table's data type detection and come through as python types, in this case typing is 
-  handled in `ConnectionWrapper._escape_value`. However dbt also allows you to override the data types of the created table 
+  handled by using bindings in `ConnectionWrapper.execute`. However dbt also allows you to override the data types of the created table 
   through setting `column_types`, this case is handled here where we have the type information of the seed table.
 #}
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,7 +5,7 @@ pytest
 dbt-tests-adapter
 mock>=1.3.0
 flake8>=3.5.0
-pytz==2017.2
+pytz
 bumpversion==0.5.3
 tox==3.2.0
 ipdb

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,15 @@
 import pytest
+import trino
 
-# Import the fuctional fixtures as a plugin
+# Import the functional fixtures as a plugin
 # Note: fixtures with session scope need to be local
 
 pytest_plugins = ["dbt.tests.fixtures.project"]
 
 # The profile dictionary, used to write out profiles.yml
 @pytest.fixture(scope="class")
-def dbt_profile_target():
-    return {
+def dbt_profile_target(request):
+    target = {
         'type': 'trino',
         'method': 'none',
         'threads': 1,
@@ -19,3 +20,21 @@ def dbt_profile_target():
         'catalog': 'memory',
         'schema': 'default'
     }
+
+    marker = request.node.get_closest_marker("prepared_statements_disabled")
+    if marker:
+        target.update({
+            'prepared_statements_enabled': False
+        })
+
+    return target
+
+@pytest.fixture(scope="class")
+def trino_connection(dbt_profile_target):
+    return trino.dbapi.connect(
+        host=dbt_profile_target['host'],
+        port=dbt_profile_target['port'],
+        user=dbt_profile_target['user'],
+        catalog=dbt_profile_target['catalog'],
+        schema=dbt_profile_target['schema']
+    )

--- a/tests/functional/adapter/materialization/test_prepared_statements.py
+++ b/tests/functional/adapter/materialization/test_prepared_statements.py
@@ -1,0 +1,74 @@
+import pytest
+from dbt.tests.util import run_dbt, check_relations_equal
+from conftest import dbt_profile_target
+
+from tests.functional.adapter.materialization.fixtures import (
+    seed_csv,
+    model_sql,
+    profile_yml,
+)
+
+
+class PreparedStatementsBase:
+    """
+    Testing prepared_statements_enabled profile configuration using dbt 
+    seed, run and tests commands and validate data load correctness.
+    """
+
+    # configuration in dbt_project.yml
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "example"
+        }
+
+    # everything that goes in the "seeds" directory
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "seed.csv": seed_csv,
+        }
+
+    # everything that goes in the "models" directory
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "materialization.sql": model_sql,
+            "materialization.yml": profile_yml,
+        }
+
+    def retrieve_num_prepared_statements(self, trino_connection):
+        cur = trino_connection.cursor()
+        cur.execute("select query from system.runtime.queries order by query_id desc limit 3")
+        result = cur.fetchall()
+        return len(list(filter(lambda rec: 'EXECUTE' in rec[0], result)))
+
+    # The actual sequence of dbt commands and assertions
+    # pytest will take care of all "setup" + "teardown"
+    def run_seed_with_prepared_statements(self, project, trino_connection, expected_num_prepared_statements):
+        # seed seeds
+        results = run_dbt(["seed"], expect_pass=True)
+        assert len(results) == 1
+
+        # Check if the seed command is using prepared statements
+        assert self.retrieve_num_prepared_statements(trino_connection) == expected_num_prepared_statements
+
+        # run models
+        results = run_dbt(["run"], expect_pass=True)
+        assert len(results) == 1
+        # test tests
+        results = run_dbt(["test"], expect_pass=True)
+        assert len(results) == 3
+
+        # check if the data was loaded correctly
+        check_relations_equal(project.adapter, ["seed", "materialization"])
+
+@pytest.mark.prepared_statements_disabled
+class TestPreparedStatementsDisabled(PreparedStatementsBase):
+    def test_run_seed_with_prepared_statements_disabled(self, project, trino_connection):
+        self.run_seed_with_prepared_statements(project, trino_connection, 0)
+
+
+class TestPreparedStatementsEnabled(PreparedStatementsBase):
+    def test_run_seed_with_prepared_statements_enabled(self, project, trino_connection):
+        self.run_seed_with_prepared_statements(project, trino_connection, 1)


### PR DESCRIPTION
## Overview

Remove prepared statements emulation from dbt-trino and rely on the prepared statements support of native python types from trino-python-client

- Description:
- Related issue(s):
- Related code pull request(s):
- Related link(s): [Improved python types from trino-python-client](https://github.com/trinodb/trino-python-client#improved-python-types), #28 

## Checklist

- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] `README.md` updated and added information about my change
- [x] `CHANGELOG.md` updated and added information about my change
