### PR TITLE
Add PostgreSQL docker container for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 ### Fixes
 
 ### Under the hood
+- Add PostgreSQL docker container for testing ([#66](https://github.com/starburstdata/dbt-trino/issues/66), [#67](https://github.com/starburstdata/dbt-trino/pull/67))
 
 Contributors:
-* [@hovaesco](https://github.com/hovaesco) ([#54](https://github.com/starburstdata/dbt-trino/pull/54))
+* [@hovaesco](https://github.com/hovaesco) ([#54](https://github.com/starburstdata/dbt-trino/pull/54), [#67](https://github.com/starburstdata/dbt-trino/pull/67))
 
 ## dbt-trino 1.0.3 (March 2, 2022)
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,8 @@ By default, all dbt models are built in the schema specified in your target. But
 
 ### Running tests
 
-Tests can be executed against Trino or Starburst server. To run all tests alongside with building required docker images and server initialization run:
+Tests can be executed against Trino or Starburst server. Docker compose creates PostgreSQL instance which can be used in tests by pointing to `postgresql` catalog.
+To run all tests alongside with building required docker images and server initialization run:
 
 ```sh
 make dbt-trino-tests

--- a/docker-compose-starburst.yml
+++ b/docker-compose-starburst.yml
@@ -8,6 +8,14 @@ services:
       - ./docker/starburst/etc:/etc/starburst
       - ./docker/starburst/catalog:/etc/starburst/catalog
 
+  postgres:
+    ports:
+      - "5432:5432"
+    image: postgres:11
+    environment:
+      POSTGRES_USER: dbt-trino
+      POSTGRES_PASSWORD: dbt-trino
+
 networks:
   default:
     external:

--- a/docker-compose-trino.yml
+++ b/docker-compose-trino.yml
@@ -8,6 +8,15 @@ services:
       - ./docker/trino/etc:/usr/lib/trino/etc:ro
       - ./docker/trino/catalog:/etc/trino/catalog
 
+  postgres:
+    ports:
+      - "5432:5432"
+    image: postgres:11
+    container_name: postgres
+    environment:
+      POSTGRES_USER: dbt-trino
+      POSTGRES_PASSWORD: dbt-trino
+
 networks:
   default:
     external:

--- a/docker/init_starburst.bash
+++ b/docker/init_starburst.bash
@@ -8,5 +8,5 @@ set -exo pipefail
 
 docker-compose -f docker-compose-starburst.yml build
 docker-compose -f docker/util.yml build
-docker-compose -f docker-compose-starburst.yml up -d trino
+docker-compose -f docker-compose-starburst.yml up -d
 docker-compose -f docker/util.yml run --rm util wait_for_up trino 8080 10

--- a/docker/init_trino.bash
+++ b/docker/init_trino.bash
@@ -8,5 +8,5 @@ set -exo pipefail
 
 docker-compose -f docker-compose-trino.yml build
 docker-compose -f docker/util.yml build
-docker-compose -f docker-compose-trino.yml up -d trino
+docker-compose -f docker-compose-trino.yml up -d
 docker-compose -f docker/util.yml run --rm util wait_for_up trino 8080

--- a/docker/starburst/catalog/postgresql.properties
+++ b/docker/starburst/catalog/postgresql.properties
@@ -1,0 +1,4 @@
+connector.name=postgresql
+connection-url=jdbc:postgresql://postgres:5432/dbt-trino
+connection-user=dbt-trino
+connection-password=dbt-trino

--- a/docker/trino/catalog/postgresql.properties
+++ b/docker/trino/catalog/postgresql.properties
@@ -1,0 +1,4 @@
+connector.name=postgresql
+connection-url=jdbc:postgresql://postgres:5432/dbt-trino
+connection-user=dbt-trino
+connection-password=dbt-trino


### PR DESCRIPTION
## Overview

- Description: Add PostgreSQL docker container for testing to test advanced features. Memory catalog cannot be completely replaced since views are not supported in PostgreSQL connector.
- Related issue(s): https://github.com/starburstdata/dbt-trino/issues/66
- Related code pull request(s): https://github.com/starburstdata/dbt-trino/pull/60
- Related link(s):

## Checklist

- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] `README.md` updated and added information about my change
- [x] `CHANGELOG.md` updated and added information about my change
