### PR TITLE
Fix veracode scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,3 +1,5 @@
+name: Veracode SCA
+
 on: 
   push:
     branches:
@@ -22,6 +24,6 @@ jobs:
 
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          quick: true
           create-issues: true 
           min-cvss-for-issue: 1
+          fail-on-cvss: 11


### PR DESCRIPTION
quick: true seems to generate following error `SCA Output file was not found - cannot proceed with creating issues. Please check prior execution errors.`