### PR TITLE
Update Slack channel links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+---
+contact_links:
+  - name: Ask a question or get help around `dbt-trino` on Slack
+    url: https://getdbt.slack.com/channels/db-presto-trino
+    about: Get help and share your experiences around `dbt-trino` with the `dbt` Slack community.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <img src="https://trino.io/assets/trino-og.png" width="50%" />
 </p>
 
-[![Build Status](https://github.com/starburstdata/dbt-trino/actions/workflows/ci.yml/badge.svg)](https://github.com/starburstdata/dbt-trino/actions/workflows/ci.yml?query=workflow%3A%22dbt-trino+tests%22+branch%3Amaster+event%3Apush) [![Trino Slack](https://img.shields.io/static/v1?logo=slack&logoColor=959DA5&label=Slack&labelColor=333a41&message=join%20conversation&color=3AC358)](https://trino.io/slack.html)
+[![Build Status](https://github.com/starburstdata/dbt-trino/actions/workflows/ci.yml/badge.svg)](https://github.com/starburstdata/dbt-trino/actions/workflows/ci.yml?query=workflow%3A%22dbt-trino+tests%22+branch%3Amaster+event%3Apush) [![db-presto-trino Slack](https://img.shields.io/static/v1?logo=slack&logoColor=959DA5&label=Slack&labelColor=333a41&message=join%20conversation&color=3AC358)](https://getdbt.slack.com/channels/db-presto-trino)
 
 # dbt-trino
 
@@ -410,7 +410,7 @@ The prepared statements can be disabled by setting `prepared_statements_enabled`
 
 ## Contributing
 
-- Want to report a bug or request a feature? Let us know on [Slack](http://community.getdbt.com/) in the #db-presto-trino channel, or open [an issue](https://github.com/starburstdata/dbt-trino/issues/new)
+- Want to report a bug or request a feature? Let us know on [Slack](http://community.getdbt.com/) in the [#db-presto-trino](https://getdbt.slack.com/channels/db-presto-trino) channel, or open [an issue](https://github.com/starburstdata/dbt-trino/issues/new)
 - Want to help us build dbt-trino? Check out the [Contributing Guide](https://github.com/starburstdata/dbt-trino/blob/HEAD/CONTRIBUTING.md)
 
 ### Release process


### PR DESCRIPTION
## Overview
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

Updated Slack channel links in order to correctly direct newbie users to the `#db-presto-trino` dbt Slack channel.


## Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] `README.md` updated and added information about my change
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
