### PR TITLE
Require pyyaml 5.4 instead of 6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     install_requires=[
         "dbt-core~={}".format(dbt_version),
         "trino==0.315.0",
-        "pyyaml>=6.0",  # TODO: remove when migrating to dbt 1.3
+        "pyyaml>=5.4",  # TODO: remove when migrating to dbt 1.3
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Just as dbt1.3 we required pyyaml 6.0, however seems that this version is not (yet) compatible with awscli. As pyyaml 5.4 is the first non-beta version to resolve the security issue, it is a safer candidate.

See https://github.com/starburstdata/dbt-trino/pull/106#issuecomment-1229173897
