### PR TITLE
Make specyfing issue number optional in changie

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -6,7 +6,7 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## dbt-trino {{.Version}} - {{.Time.Format "January 02, 2006"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '- {{.Body}} ([#{{.Custom.Issue}}](https://github.com/starburstdata/dbt-trino/issues/{{.Custom.Issue}}), [#{{.Custom.PR}}](https://github.com/starburstdata/dbt-trino/pull/{{.Custom.PR}}))'
+changeFormat: '- {{.Body}} ({{if ne .Custom.Issue ""}}[#{{.Custom.Issue}}](https://github.com/starburstdata/dbt-trino/issues/{{.Custom.Issue}}), {{end}}[#{{.Custom.PR}}](https://github.com/starburstdata/dbt-trino/pull/{{.Custom.PR}}))'
 
 kinds:
   - label: Breaking Changes
@@ -30,6 +30,7 @@ custom:
     label: GitHub Issue Number
     type: int
     minInt: 1
+    optional: true
   - key: PR
     label: GitHub Pull Request Number
     type: int

--- a/.github/workflows/bot-changelog.yml
+++ b/.github/workflows/bot-changelog.yml
@@ -54,4 +54,4 @@ jobs:
           commit_message: ${{ github.event.pull_request.title }}
           changie_kind: "Dependencies"
           label: "dependencies"
-          custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  Issue: 27\n  PR: ${{ github.event.pull_request.number }}"
+          custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  Issue: ''\n  PR: ${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Overview
Make specyfing issue number optional in changie

## Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
