### PR TITLE
Skip running Galaxy tests on PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,12 @@ jobs:
         python:
           - "3.9"
           - "3.10"
+        isForkBranch:
+          - ${{ !contains(github.event.pull_request.head.repo.full_name, 'starburstdata') }}
         exclude:
+          - engine: "starburst_galaxy"
+            python: "3.9"
+            isForkBranch: true
           - engine: "starburst_galaxy"
             python: "3.10"
 


### PR DESCRIPTION
## Overview
Skip running Galaxy tests on PRs from forks
## Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
