### PR TITLE
`dbt_utils` upgrade related improvements

### DIFF
--- a/.changes/unreleased/Under the Hood-20221004-105758.yaml
+++ b/.changes/unreleased/Under the Hood-20221004-105758.yaml
@@ -1,0 +1,8 @@
+kind: Under the Hood
+body: Change `get_columns_in_relation` implementation to use `describe` to also support
+  string relations
+time: 2022-10-04T10:57:58.186935+02:00
+custom:
+  Author: mdesmet
+  Issue: ""
+  PR: "145"

--- a/dbt/adapters/trino/impl.py
+++ b/dbt/adapters/trino/impl.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional
 import agate
 from dbt.adapters.base.impl import AdapterConfig
 from dbt.adapters.sql import SQLAdapter
+from dbt.exceptions import DatabaseException
 
 from dbt.adapters.trino import TrinoColumn, TrinoConnectionManager, TrinoRelation
 
@@ -43,3 +44,12 @@ class TrinoAdapter(SQLAdapter):
 
     def timestamp_add_sql(self, add_to: str, number: int = 1, interval: str = "hour") -> str:
         return f"{add_to} + interval '{number}' {interval}"
+
+    def get_columns_in_relation(self, relation):
+        try:
+            return super().get_columns_in_relation(relation)
+        except DatabaseException as exc:
+            if "does not exist" in str(exc):
+                return []
+            else:
+                raise

--- a/dbt/include/trino/macros/crossdb/split_part.sql
+++ b/dbt/include/trino/macros/crossdb/split_part.sql
@@ -1,0 +1,7 @@
+{% macro trino__split_part(string_text, delimiter_text, part_number) %}
+  {% if part_number >= 0 %}
+    {{ dbt.default__split_part(string_text, delimiter_text, part_number) }}
+  {% else %}
+    {{ dbt._split_part_negative(string_text, delimiter_text, part_number) }}
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
## Overview

get_columns_in_relation also accepts string parameters instead of `Relation` instances. These won't have `information_schema` property and therefore these queries will fail.

Improved exception handling

added macro `split_part`

## Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
