### PR TITLE
Fixes instantiation of CertificateAuthentication object from trino-python-client

### DIFF
--- a/.changes/unreleased/Fixes-20221009-132438.yaml
+++ b/.changes/unreleased/Fixes-20221009-132438.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fixes instantiation of CertificateAuthentication object from trino-python-client
+time: 2022-10-09T13:24:38.264985+02:00
+custom:
+  Author: KateShopify
+  Issue: "149"
+  PR: "150"

--- a/dbt/adapters/trino/connections.py
+++ b/dbt/adapters/trino/connections.py
@@ -131,8 +131,7 @@ class TrinoCertificateCredentials(TrinoCredentials):
 
     def trino_auth(self):
         return trino.auth.CertificateAuthentication(
-            client_certificate=self.client_certificate,
-            client_private_key=self.client_private_key,
+            self.client_certificate, self.client_private_key
         )
 
 

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -266,6 +266,11 @@ class TestTrinoAdapterAuthenticationMethods(unittest.TestCase):
         )
         credentials = connection.credentials
         self.assertIsInstance(credentials, TrinoCertificateCredentials)
+        self.assertIsInstance(credentials.trino_auth(), trino.auth.CertificateAuthentication)
+        self.assertEqual(
+            credentials.trino_auth(),
+            trino.auth.CertificateAuthentication("/path/to/client_cert", "password"),
+        )
         self.assert_default_connection_credentials(credentials)
         self.assertEqual(credentials.http_scheme, HttpScheme.HTTPS)
         self.assertEqual(credentials.cert, "/path/to/cert")


### PR DESCRIPTION
## Overview
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->
resolves https://github.com/starburstdata/dbt-trino/issues/149 To work with certificate authentication in [`trino-python-client`](https://github.com/trinodb/trino-python-client)
Not updating any functionality or function signatures, so the README should not need an update. 
## Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] `README.md` updated and added information about my change
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
