### PR TITLE
Upgrade to latest Trino/Starburst/Trino Python Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository represents a fork of the [dbt-presto](https://github.com/dbt-lab
 
 ### Compatibility
 
-This dbt plugin has been tested against `Trino` version `397`, `Starburst Enterprise` version `396` and `Starburst Galaxy`.
+This dbt plugin has been tested against `Trino` version `398`, `Starburst Enterprise` version `398-e` and `Starburst Galaxy`.
 
 ## Installation
 

--- a/dbt/adapters/trino/connections.py
+++ b/dbt/adapters/trino/connections.py
@@ -394,7 +394,7 @@ class TrinoConnectionManager(SQLConnectionManager):
             schema=credentials.schema,
             http_scheme=credentials.http_scheme.value,
             http_headers=credentials.http_headers,
-            session_properties=credentials.session_properties.copy(),
+            session_properties=credentials.session_properties,
             auth=credentials.trino_auth(),
             max_attempts=credentials.retries,
             isolation_level=IsolationLevel.AUTOCOMMIT,

--- a/docker-compose-starburst.yml
+++ b/docker-compose-starburst.yml
@@ -3,7 +3,7 @@ services:
   trino:
     ports:
       - "8080:8080"
-    image: "starburstdata/starburst-enterprise:396-e"
+    image: "starburstdata/starburst-enterprise:398-e"
     volumes:
       - ./docker/starburst/etc:/etc/starburst
       - ./docker/starburst/catalog:/etc/starburst/catalog

--- a/docker-compose-trino.yml
+++ b/docker-compose-trino.yml
@@ -3,7 +3,7 @@ services:
   trino:
     ports:
       - "8080:8080"
-    image: "trinodb/trino:397"
+    image: "trinodb/trino:398"
     volumes:
       - ./docker/trino/etc:/usr/lib/trino/etc:ro
       - ./docker/trino/catalog:/etc/trino/catalog

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     },
     install_requires=[
         "dbt-core~={}".format(dbt_version),
-        "trino==0.315.0",
+        "trino==0.318.0",
         "pyyaml>=5.4",  # TODO: remove when migrating to dbt 1.3
     ],
     zip_safe=False,


### PR DESCRIPTION
## Overview

Upgrade to latest Trino/Starburst/Trino Python Client

Now we do a defensive copy of each reference type in Trino Python Client's `ClientSession`, so `copy()` can be removed.

## Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] `README.md` updated and added information about my change
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
