### PR TITLE
Add brew to PATH for version bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           python-version: "3.8"
 
+      - name: Install brew
+        run: |
+          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+
       - name: Install python dependencies
         run: |
           python3 -m venv env


### PR DESCRIPTION
## Overview

Version bump depends on brew

brew has been removed from PATH in the ubuntu-latest runner. See https://github.com/actions/runner-images/issues/6283

## Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
