### PR TITLE
Fix table not dropped on incremental full refresh

### DIFF
--- a/.changes/unreleased/Fixes-20221025-165844.yaml
+++ b/.changes/unreleased/Fixes-20221025-165844.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix table not dropped on `full-refresh` of incremental models
+time: 2022-10-25T16:58:44.16598+02:00
+custom:
+  Author: mdesmet
+  Issue: ""
+  PR: "168"

--- a/dbt/include/trino/macros/materializations/incremental.sql
+++ b/dbt/include/trino/macros/materializations/incremental.sql
@@ -51,6 +51,8 @@
       {{ create_table_as(False, target_relation, compiled_code, language) }}
     {%- endcall -%}
   {% elif full_refresh_mode %}
+    {#-- Can't replace a table - we must drop --#}
+    {% do adapter.drop_relation(existing_relation) %}
     {%- call statement('main', language=language) -%}
       {{ create_table_as(False, target_relation, compiled_code, language) }}
     {%- endcall -%}

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -16,6 +16,7 @@ from dbt.tests.adapter.basic.test_singular_tests_ephemeral import (
     BaseSingularTestsEphemeral,
 )
 from dbt.tests.adapter.basic.test_validate_connection import BaseValidateConnection
+from dbt.tests.util import run_dbt
 
 seeds_base_csv = """
 id,name,some_date
@@ -162,6 +163,13 @@ class TestIncrementalTrino(BaseIncremental):
     @pytest.fixture(scope="class")
     def seeds(self):
         return {"base.csv": seeds_base_csv, "added.csv": seeds_added_csv}
+
+
+class TestIncrementalFullRefreshTrino(BaseIncremental):
+    def test_incremental(self, project):
+        super().test_incremental(project)
+        results = run_dbt(["run", "--vars", "seed_name: base", "--full-refresh"])
+        assert len(results) == 1
 
 
 class TestIncrementalNotSchemaChangeTrino(BaseIncrementalNotSchemaChange):


### PR DESCRIPTION
## Overview

Fix issue with `--full-refresh` on incremental models and added explicit test.

## Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
