### PR TITLE
fix: correctly handle unbound varchar case instead of defaulting to varchar(256)

### DIFF
--- a/.changes/unreleased/Fixes-20221209-114403.yaml
+++ b/.changes/unreleased/Fixes-20221209-114403.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Handle unbound varchar data_type instead of defaulting to varchar(256)
+time: 2022-12-09T11:44:03.689108-08:00
+custom:
+  Author: kalvinnchau
+  Issue: "35"
+  PR: "194"

--- a/dbt/adapters/trino/column.py
+++ b/dbt/adapters/trino/column.py
@@ -5,6 +5,10 @@ from typing import ClassVar, Dict
 from dbt.adapters.base.column import Column
 from dbt.exceptions import RuntimeException
 
+# Taken from the MAX_LENGTH variable in
+# https://github.com/trinodb/trino/blob/master/core/trino-spi/src/main/java/io/trino/spi/type/VarcharType.java
+TRINO_VARCHAR_MAX_LENGTH = 2147483646
+
 
 @dataclass
 class TrinoColumn(Column):
@@ -27,6 +31,13 @@ class TrinoColumn(Column):
     @classmethod
     def string_type(cls, size: int) -> str:
         return "varchar({})".format(size)
+
+    def string_size(self) -> int:
+        # override the string_size function to handle the unbound varchar case
+        if self.dtype.lower() == "varchar" and self.char_size is None:
+            return TRINO_VARCHAR_MAX_LENGTH
+
+        return super().string_size()
 
     @classmethod
     def from_description(cls, name: str, raw_data_type: str) -> "Column":

--- a/dbt/adapters/trino/column.py
+++ b/dbt/adapters/trino/column.py
@@ -15,6 +15,15 @@ class TrinoColumn(Column):
         "INTEGER": "INT",
     }
 
+    @property
+    def data_type(self):
+        # when varchar has no defined size, default to unbound varchar
+        # the super().data_type defaults to varchar(256)
+        if self.dtype.lower() == "varchar" and self.char_size is None:
+            return self.dtype
+
+        return super().data_type
+
     @classmethod
     def string_type(cls, size: int) -> str:
         return "varchar({})".format(size)

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -10,6 +10,7 @@ from dbt.clients import agate_helper
 from dbt.exceptions import DatabaseException, FailedToConnectException, RuntimeException
 
 from dbt.adapters.trino import TrinoAdapter
+from dbt.adapters.trino.column import TRINO_VARCHAR_MAX_LENGTH, TrinoColumn
 from dbt.adapters.trino.connections import (
     HttpScheme,
     TrinoCertificateCredentials,
@@ -530,3 +531,28 @@ class TestTrinoAdapterConversions(TestAdapterConversions):
         expected = ["DATE", "DATE", "DATE"]
         for col_idx, expect in enumerate(expected):
             assert TrinoAdapter.convert_date_type(agate_table, col_idx) == expect
+
+
+class TestTrinoColumn(unittest.TestCase):
+    def test_bound_varchar(self):
+        col = TrinoColumn.from_description("my_col", "VARCHAR(100)")
+        assert col.column == "my_col"
+        assert col.dtype == "VARCHAR"
+        assert col.char_size == 100
+        # bounded varchars get formatted to lowercase
+        assert col.data_type == "varchar(100)"
+        assert col.string_size() == 100
+        assert col.is_string() is True
+        assert col.is_number() is False
+        assert col.is_numeric() is False
+
+    def test_unbound_varchar(self):
+        col = TrinoColumn.from_description("my_col", "VARCHAR")
+        assert col.column == "my_col"
+        assert col.dtype == "VARCHAR"
+        assert col.char_size is None
+        assert col.data_type == "VARCHAR"
+        assert col.string_size() == TRINO_VARCHAR_MAX_LENGTH
+        assert col.is_string() is True
+        assert col.is_number() is False
+        assert col.is_numeric() is False


### PR DESCRIPTION


## Overview
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

This is related to #35, the linked issue listed two separate issues, and one was already resolved.
>one is with dbt core: the varying(256) is hardcoded in dbt core and doesn't use the overriden TrinoColumn class methods. see [CT-78] [Bug] Adapters should be able to override string and numeric type of columns dbt-labs/dbt-core#4603 (PR submitted)

Now that the dbt-core PR has been merged, we can use the `TrinoColumn` class to handle the hard-coded `256`, the super class implementation still checks if `char_size is None` and sets it to `256` if is it `None.

https://github.com/dbt-labs/dbt-core/blob/0544b085439b3a635b8ce56adbf56d8e7c7e6839/core/dbt/adapters/base/column.py#L86-L94


In [dbt_utils.union_relations](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/union.sql) it uses the `col.data_type` property to get the type 
https://github.com/dbt-labs/dbt-utils/blob/84cf0f2971f5bf539b06c42373a5e80b59ba7047/macros/sql/union.sql#L102-L111

Given two tables:
```sql
CREATE TABLE test.test_union_1 (
    str VARCHAR,
    str_10 VARCHAR(10)
);

CREATE TABLE test.test_union_2 (
    str VARCHAR, 
    str_10 VARCHAR(10),
    str_20 VARCHAR(20)
);
```

The `dbt_utils.union_relations` macro currently produces:
```sql
{% set relations = trino__get_relations_by_pattern('test', 'test_union%') %}

{{ dbt_utils.union_relations(relations = filtered_relations) }}
-->
(
  SELECT
    CAST('default.test.test_union_1' AS VARCHAR)
      AS _dbt_source_relation,
    CAST(str AS VARCHAR(256)) AS str,        # we didn't set any max
    CAST(str_10 AS VARCHAR(10)) AS str_10,
    CAST(NULL AS VARCHAR(20)) AS str_20
  FROM
    default.test.test_union_1
)
UNION ALL
(
  SELECT
    CAST('default.test.test_union_2' AS VARCHAR)
      AS _dbt_source_relation,
    CAST(str AS VARCHAR(256)) AS str,
    CAST(str_10 AS VARCHAR(10)) AS str_10,
    CAST(str_20 AS VARCHAR(20)) AS str_20
  FROM
    default.test.test_union_2
);
```

This change allows the `dbt_utils.union_relations` to produce the expected output of:
```sql
(
  SELECT
    CAST('default.test.test_union_1' AS VARCHAR)
      AS _dbt_source_relation,
    CAST(str AS VARCHAR) AS str,
    CAST(str_10 AS VARCHAR(10)) AS str_10,
    CAST(NULL AS VARCHAR(20)) AS str_20
  FROM
    default.test.test_union_1
)
UNION ALL
(
  SELECT
    CAST('default.test.test_union_2' AS VARCHAR)
      AS _dbt_source_relation,
    CAST(str AS VARCHAR) AS str,
    CAST(str_10 AS VARCHAR(10)) AS str_10,
    CAST(str_20 AS VARCHAR(20)) AS str_20
  FROM
    default.test.test_union_2
);
```


Let me know if there's some place to easily add in tests for this sort of case and I can do that.

## Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] `README.md` updated and added information about my change
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
