### PR TITLE
Added custom materialization for materialized view

### DIFF
--- a/.changes/unreleased/Features-20221215-112009.yaml
+++ b/.changes/unreleased/Features-20221215-112009.yaml
@@ -1,7 +1,6 @@
 kind: Features
-body: Added initial code for a custom materialization, materialized view in starburst
+body: Support Materialized View materialization
 time: 2022-12-15T11:20:09.053826Z
 custom:
   Author: Jay-code0
-  Issue: "900000"
   PR: "198"

--- a/.changes/unreleased/Features-20221215-112009.yaml
+++ b/.changes/unreleased/Features-20221215-112009.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Added initial code for a custom materialization, materialized view in starburst
+time: 2022-12-15T11:20:09.053826Z
+custom:
+  Author: Jay-code0
+  Issue: "900000"
+  PR: "198"

--- a/dbt/include/trino/macros/materializations/materialized_view.sql
+++ b/dbt/include/trino/macros/materializations/materialized_view.sql
@@ -1,0 +1,80 @@
+{% materialization trino_materialized_view, adapter="trino" %} 
+{%- set target_relation = this %}
+{%- set existing_relation = load_relation(this) -%}
+{%- set config_grace_period = config.require('grace_period') %}
+{%- set config_max_import_duration = config.require('max_import_duration') %}
+{%- set config_drop_any_existing = config.require('drop_any_existing') %}
+{%- set config_cron = config.get('cron') %}
+{%- set config_refresh_interval = config.get('refresh_interval') %}
+
+
+{{ run_hooks(pre_hooks) }}
+
+{% if existing_relation is none %}
+
+    {{ log("No existing view found, creating materialized view...", info=true) }}
+    {%- set build_sql = build_materialized_view(target_relation,config_grace_period,config_max_import_duration,config_cron,config_refresh_interval) %}
+
+{% else %}
+    {%- if existing_relation.is_view %}
+        {%-set existing_type = 'view'%}
+    {%- elif existing_relation.is_table %}
+        {%-set existing_type = 'table'%}
+    {%- elif existing_relation.is_cte %}
+        {%-set existing_type = 'CTE'%}
+    {% endif %}
+
+    {%- if existing_type is not none and config_drop_any_existing == 'False' %}
+        {{ log("Found a " ~ existing_type ~ " with same name.", info=true) }}
+        {%- set build_sql = build_materialized_view(target_relation,config_grace_period,config_max_import_duration,config_cron,config_refresh_interval) %}
+
+    {% elif existing_type is not none and config_drop_any_existing == 'True' and existing_type != 'table'%} -- theres an issue with starburst thinking that the materialised view is a table in the information schema, hence the logic on this line
+        {%- set drop_existing_sql = "DROP " ~ existing_type ~ " IF EXISTS " ~ existing_relation %}
+        {%- set build_sql = build_materialized_view(target_relation,config_grace_period,config_max_import_duration,config_cron,config_refresh_interval) %}
+        {%- call statement('drop_existing') -%}
+            {{ drop_existing_sql }} 
+        {% endcall %}
+
+    {% else %}
+        {{ log("Found something with same name, trying to create materialized view anyway...", info=true) }}
+        {%- set build_sql = build_materialized_view(target_relation,config_grace_period,config_max_import_duration,config_cron,config_refresh_interval) %}
+    {% endif %}
+    
+{% endif %}
+
+-- Sends the sql command to starburst
+{%- call statement('main') -%}
+    {{ build_sql }} 
+{% endcall %}
+
+{{ run_hooks(pre_hooks) }}
+
+{{ return({'relations': [target_relation]}) }}
+
+{% endmaterialization %}
+
+---------------- Macros -------------------
+
+{%- macro build_materialized_view(target_relation,config_grace_period,config_max_import_duration,config_cron,config_refresh_interval) -%}
+{% if config_cron is not none and config_refresh_interval is not none %}
+    {{ log("Found config for CRON and Refresh Interval, error will be thrown as only 1 is allowed", info=true) }}
+    {{ exceptions.raise_compiler_error("Invalid config: only CRON or refresh interval allowed - " ~ config_cron ~ " - " ~ config_refresh_interval) }}
+
+{% else %}  
+    {% if config_cron is not none and config_refresh_interval is none %}
+        {%- set schedule_to_use ="cron = \'" ~  config_cron  ~ "\'," %}
+    {% else %}
+        {%- set schedule_to_use ="refresh_interval = \'" ~  config_refresh_interval  ~ "\'," %}
+    {% endif %}
+
+    {%- set sqlcode= "CREATE OR REPLACE MATERIALIZED VIEW " ~  target_relation ~ " WITH (
+    " ~ schedule_to_use ~ 
+    "grace_period = \'" ~  config_grace_period  ~ "\',
+    max_import_duration = \'" ~  config_max_import_duration  ~ "\'
+    ) AS" ~ sql
+    %}
+
+    {{sqlcode}} 
+
+{% endif %}
+{%- endmacro -%}

--- a/dbt/include/trino/macros/materializations/materialized_view.sql
+++ b/dbt/include/trino/macros/materializations/materialized_view.sql
@@ -1,4 +1,4 @@
-{% materialization trino_materialized_view, adapter="trino" %} 
+{% materialization materialized_view, adapter="trino" %} 
 {%- set target_relation = this %}
 {%- set existing_relation = load_relation(this) -%}
 {%- set config_grace_period = config.require('grace_period') %}
@@ -12,8 +12,8 @@
 
 {% if existing_relation is none %}
 
-    {{ log("No existing view found, creating materialized view...", info=true) }}
-    {%- set build_sql = build_materialized_view(target_relation,config_grace_period,config_max_import_duration,config_cron,config_refresh_interval) %}
+    {{ log("No existing materialized view found, creating materialized view...", info=true) }}
+    {%- set build_sql = build_materialized_view(target_relation, config_grace_period, config_max_import_duration, config_cron, config_refresh_interval) %}
 
 {% else %}
     {%- if existing_relation.is_view %}
@@ -26,18 +26,18 @@
 
     {%- if existing_type is not none and config_drop_any_existing == 'False' %}
         {{ log("Found a " ~ existing_type ~ " with same name.", info=true) }}
-        {%- set build_sql = build_materialized_view(target_relation,config_grace_period,config_max_import_duration,config_cron,config_refresh_interval) %}
+        {%- set build_sql = build_materialized_view(target_relation, config_grace_period, config_max_import_duration, config_cron, config_refresh_interval) %}
 
     {% elif existing_type is not none and config_drop_any_existing == 'True' and existing_type != 'table'%} -- theres an issue with starburst thinking that the materialised view is a table in the information schema, hence the logic on this line
         {%- set drop_existing_sql = "DROP " ~ existing_type ~ " IF EXISTS " ~ existing_relation %}
-        {%- set build_sql = build_materialized_view(target_relation,config_grace_period,config_max_import_duration,config_cron,config_refresh_interval) %}
+        {%- set build_sql = build_materialized_view(target_relation, config_grace_period, config_max_import_duration, config_cron, config_refresh_interval) %}
         {%- call statement('drop_existing') -%}
             {{ drop_existing_sql }} 
         {% endcall %}
 
     {% else %}
         {{ log("Found something with same name, trying to create materialized view anyway...", info=true) }}
-        {%- set build_sql = build_materialized_view(target_relation,config_grace_period,config_max_import_duration,config_cron,config_refresh_interval) %}
+        {%- set build_sql = build_materialized_view(target_relation, config_grace_period, config_max_import_duration, config_cron, config_refresh_interval) %}
     {% endif %}
     
 {% endif %}
@@ -55,7 +55,7 @@
 
 ---------------- Macros -------------------
 
-{%- macro build_materialized_view(target_relation,config_grace_period,config_max_import_duration,config_cron,config_refresh_interval) -%}
+{%- macro build_materialized_view(target_relation, config_grace_period, config_max_import_duration, config_cron, config_refresh_interval) -%}
 {% if config_cron is not none and config_refresh_interval is not none %}
     {{ log("Found config for CRON and Refresh Interval, error will be thrown as only 1 is allowed", info=true) }}
     {{ exceptions.raise_compiler_error("Invalid config: only CRON or refresh interval allowed - " ~ config_cron ~ " - " ~ config_refresh_interval) }}
@@ -78,3 +78,4 @@
 
 {% endif %}
 {%- endmacro -%}
+


### PR DESCRIPTION
## Overview
This new materialization will allow users to create models in dbt which will send the relevant command to starburst to create and schedule a materialized view, current stage of code will do the common config items and also requires the model to send a config item for dropping an existing item with the same name if not the same type (view.cte.table)

## Checklist

- [ x] I have run this code in development and it appears to resolve the stated issue
- [ x] This PR includes tests, or tests are not required/relevant for this PR
- [ x] `README.md` updated and added information about my change
- [ x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
