### PR TITLE
Update current_timestamp macro to precision 6 with time zone

### DIFF
--- a/dbt/include/trino/macros/utils/timestamps.sql
+++ b/dbt/include/trino/macros/utils/timestamps.sql
@@ -1,5 +1,5 @@
 {% macro trino__current_timestamp() -%}
-    current_timestamp
+    cast(current_timestamp as timestamp(6) with time zone)
 {%- endmacro %}
 
 {% macro trino__snapshot_string_as_time(timestamp) %}

--- a/dbt/include/trino/macros/utils/timestamps.sql
+++ b/dbt/include/trino/macros/utils/timestamps.sql
@@ -1,5 +1,5 @@
 {% macro trino__current_timestamp() -%}
-    cast(current_timestamp(6) as timestamp(6) with time zone)
+    current_timestamp(6)
 {%- endmacro %}
 
 {% macro trino__snapshot_string_as_time(timestamp) %}

--- a/dbt/include/trino/macros/utils/timestamps.sql
+++ b/dbt/include/trino/macros/utils/timestamps.sql
@@ -1,5 +1,5 @@
 {% macro trino__current_timestamp() -%}
-    cast(current_timestamp as timestamp(6) with time zone)
+    cast(current_timestamp(6) as timestamp(6) with time zone)
 {%- endmacro %}
 
 {% macro trino__snapshot_string_as_time(timestamp) %}


### PR DESCRIPTION
## Overview
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

This PR changes the `current_timestamp` macro to use 
* precision 6, making it compatible with the iceberg file format
* a time zone, making it explicit that the timestamp stored in snapshots is a UTC timestamp

Trouble described here: https://github.com/starburstdata/dbt-trino/issues/126 
But also here: https://github.com/dbt-labs/dbt-core/issues/5867

## Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
