### PR TITLE
Use views for the creating the temporary models in Delta tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository represents a fork of the [dbt-presto](https://github.com/dbt-lab
 
 ### Compatibility
 
-This dbt plugin has been tested against `Trino` version `403`, `Starburst Enterprise` version `402-e.0` and `Starburst Galaxy`.
+This dbt plugin has been tested against `Trino` version `405`, `Starburst Enterprise` version `402-e.0` and `Starburst Galaxy`.
 
 ## Installation
 

--- a/docker-compose-trino.yml
+++ b/docker-compose-trino.yml
@@ -3,7 +3,7 @@ services:
   trino:
     ports:
       - "8080:8080"
-    image: "trinodb/trino:403"
+    image: "trinodb/trino:405"
     volumes:
       - ./docker/trino/etc:/usr/lib/trino/etc:ro
       - ./docker/trino/catalog:/etc/trino/catalog

--- a/tests/functional/adapter/materialization/test_incremental_merge.py
+++ b/tests/functional/adapter/materialization/test_incremental_merge.py
@@ -140,11 +140,9 @@ class TestDeltaIncrementalMerge(TrinoIncrementalUniqueKey):
     def project_config_update(self):
         return {
             "name": "incremental",
-            # TODO: remove `views_enabled` when https://github.com/trinodb/trino/pull/11763 is merged
             "models": {
                 "+on_table_exists": "drop",
                 "+incremental_strategy": "merge",
-                "+views_enabled": False,
             },
             "seeds": {"incremental": {"seed": {"+column_types": {"some_date": "date"}}}},
         }

--- a/tests/functional/adapter/materialization/test_incremental_schema.py
+++ b/tests/functional/adapter/materialization/test_incremental_schema.py
@@ -206,11 +206,9 @@ class TestDeltaOnSchemaChange(OnSchemaChangeBase):
     def project_config_update(self):
         return {
             "name": "on_schema_change_delta",
-            # TODO: remove views_enabled when https://github.com/trinodb/trino/pull/11763 is merged
             "models": {
                 "+on_table_exists": "drop",
                 "+incremental_strategy": "merge",
-                "+views_enabled": False,
             },
         }
 


### PR DESCRIPTION
## Overview
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

Now that there can be used Trino views in Delta Lake connector - see https://github.com/trinodb/trino/pull/11763 - there is no need to set `views_enabled` to `false` for the temporary models in the tests.

## Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] `README.md` updated and added information about my change
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
