### PR TITLE
Add query_id to adapter response

### DIFF
--- a/.changes/unreleased/Features-20230223-185937.yaml
+++ b/.changes/unreleased/Features-20230223-185937.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: add query_id to adapter response
+time: 2023-02-23T18:59:37.406854+08:00
+custom:
+  Author: aezomz
+  Issue: "210"
+  PR: "211"

--- a/dbt/adapters/trino/connections.py
+++ b/dbt/adapters/trino/connections.py
@@ -89,6 +89,11 @@ class TrinoCredentials(Credentials, metaclass=ABCMeta):
 
 
 @dataclass
+class TrinoAdapterResponse(AdapterResponse):
+    query_id: str = ""
+
+
+@dataclass
 class TrinoNoneCredentials(TrinoCredentials):
     host: str
     port: Port
@@ -442,9 +447,12 @@ class TrinoConnectionManager(SQLConnectionManager):
         return connection
 
     @classmethod
-    def get_response(cls, cursor) -> AdapterResponse:
+    def get_response(cls, cursor) -> TrinoAdapterResponse:
         message = "SUCCESS"
-        return AdapterResponse(_message=message)
+        return TrinoAdapterResponse(
+            _message=message,
+            query_id=cursor._cursor.query_id,
+        )
 
     def cancel(self, connection):
         connection.handle.cancel()

--- a/tests/functional/adapter/materialization/test_prepared_statements.py
+++ b/tests/functional/adapter/materialization/test_prepared_statements.py
@@ -63,6 +63,8 @@ class PreparedStatementsBase:
         # run models
         results = run_dbt(["run"], expect_pass=True)
         assert len(results) == 1
+        assert results[0].adapter_response.get("_message") == "SUCCESS"
+        assert results[0].adapter_response.get("query_id")
         # test tests
         results = run_dbt(["test"], expect_pass=True)
         assert len(results) == 3

--- a/tests/functional/adapter/store_failures/test_store_failures.py
+++ b/tests/functional/adapter/store_failures/test_store_failures.py
@@ -53,6 +53,8 @@ class TestStoreFailuresTable:
         assert len(results) == 1
         # test tests
         results = run_dbt(["test"], expect_pass=True)
+        assert results[0].adapter_response.get("_message") == "SUCCESS"
+        assert results[0].adapter_response.get("query_id")
         assert len(results) == 5
         # test tests 2nd times
         results = run_dbt(["test"], expect_pass=True)


### PR DESCRIPTION
## Overview
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->
Add query_id and compiled_query to adapter response
Pending rowcount if possible.

resolve https://github.com/starburstdata/dbt-trino/issues/210 
## Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [] `README.md` updated and added information about my change
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
