### PR TITLE
1.3.backport fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ start-trino:
 
 dbt-trino-tests: start-trino
 	pip install -r dev_requirements.txt
-	tox -r  || ./docker/remove_trino.bash
-	./docker/remove_trino.bash
+	tox -r
 
 start-starburst:
 	docker network create dbt-net || true
@@ -19,8 +18,7 @@ start-starburst:
 
 dbt-starburst-tests: start-starburst
 	pip install -r dev_requirements.txt
-	tox -r || ./docker/remove_starburst.bash
-	./docker/remove_starburst.bash
+	tox -r
 
 dev:
 	pre-commit install

--- a/dbt/adapters/trino/connections.py
+++ b/dbt/adapters/trino/connections.py
@@ -18,6 +18,8 @@ from dbt.exceptions import DatabaseException, FailedToConnectException, RuntimeE
 from dbt.helper_types import Port
 from trino.transaction import IsolationLevel
 
+from dbt.adapters.trino.__version__ import version
+
 logger = AdapterLogger("Trino")
 PREPARED_STATEMENTS_ENABLED_DEFAULT = True
 
@@ -427,7 +429,7 @@ class TrinoConnectionManager(SQLConnectionManager):
             auth=credentials.trino_auth(),
             max_attempts=credentials.retries,
             isolation_level=IsolationLevel.AUTOCOMMIT,
-            source="dbt-trino",
+            source=f"dbt-trino-{version}",
             verify=credentials.cert,
         )
         connection.state = "open"

--- a/docker-compose-starburst.yml
+++ b/docker-compose-starburst.yml
@@ -3,7 +3,7 @@ services:
   trino:
     ports:
       - "8080:8080"
-    image: "starburstdata/starburst-enterprise:402-e.0"
+    image: "starburstdata/starburst-enterprise:405-e"
     volumes:
       - ./docker/starburst/etc:/etc/starburst
       - ./docker/starburst/catalog:/etc/starburst/catalog

--- a/docker-compose-trino.yml
+++ b/docker-compose-trino.yml
@@ -3,7 +3,7 @@ services:
   trino:
     ports:
       - "8080:8080"
-    image: "trinodb/trino:403"
+    image: "trinodb/trino:406"
     volumes:
       - ./docker/trino/etc:/usr/lib/trino/etc:ro
       - ./docker/trino/catalog:/etc/trino/catalog

--- a/docker/starburst/catalog/delta.properties
+++ b/docker/starburst/catalog/delta.properties
@@ -8,4 +8,4 @@ hive.s3.aws-secret-key=minio123
 hive.metastore-cache-ttl=0s
 hive.metastore-refresh-interval=5s
 hive.metastore-timeout=10s
-hive.security=allow-all
+delta.security=allow-all

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     },
     install_requires=[
         "dbt-core~={}".format(dbt_version),
-        "trino==0.319.0",
+        "trino~=0.319.0",
     ],
     zip_safe=False,
     classifiers=[

--- a/tests/functional/adapter/materialization/test_prepared_statements.py
+++ b/tests/functional/adapter/materialization/test_prepared_statements.py
@@ -72,11 +72,13 @@ class PreparedStatementsBase:
 
 
 @pytest.mark.prepared_statements_disabled
+@pytest.mark.skip_profile("starburst_galaxy")
 class TestPreparedStatementsDisabled(PreparedStatementsBase):
     def test_run_seed_with_prepared_statements_disabled(self, project, trino_connection):
         self.run_seed_with_prepared_statements(project, trino_connection, 0)
 
 
+@pytest.mark.skip_profile("starburst_galaxy")
 class TestPreparedStatementsEnabled(PreparedStatementsBase):
     def test_run_seed_with_prepared_statements_enabled(self, project, trino_connection):
         self.run_seed_with_prepared_statements(project, trino_connection, 1)


### PR DESCRIPTION
- Add version in 'source' connection parameter
- Fix CI
- Disable prepared_statement tests on Galaxy
- Bump Trino and SEP versions in docker-compose files
- Unpin trino-python-client version