### PR TITLE
1.2.backport fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,8 @@ start-trino:
 
 dbt-trino-tests: start-trino
 	pip install -r dev_requirements.txt
-	tox -r  || ./docker/remove_trino.bash
+	tox -r
 	./docker/run_tests.bash
-	./docker/remove_trino.bash
 
 start-starburst:
 	docker network create dbt-net || true
@@ -22,9 +21,8 @@ start-starburst:
 
 dbt-starburst-tests: start-starburst
 	pip install -r dev_requirements.txt
-	tox -r || ./docker/remove_starburst.bash
+	tox -r
 	./docker/run_tests.bash
-	./docker/remove_starburst.bash
 
 dev:
 	pre-commit install

--- a/dbt/adapters/trino/connections.py
+++ b/dbt/adapters/trino/connections.py
@@ -19,6 +19,8 @@ from dbt.exceptions import DatabaseException, FailedToConnectException, RuntimeE
 from dbt.helper_types import Port
 from trino.transaction import IsolationLevel
 
+from dbt.adapters.trino.__version__ import version
+
 logger = AdapterLogger("Trino")
 PREPARED_STATEMENTS_ENABLED_DEFAULT = True
 
@@ -418,7 +420,7 @@ class TrinoConnectionManager(SQLConnectionManager):
             auth=credentials.trino_auth(),
             max_attempts=credentials.retries,
             isolation_level=IsolationLevel.AUTOCOMMIT,
-            source="dbt-trino",
+            source=f"dbt-trino-{version}",
         )
         trino_conn._http_session.verify = credentials.cert
         connection.state = "open"

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     },
     install_requires=[
         "dbt-core~={}".format(dbt_version),
-        "trino==0.318.0",
+        "trino~=0.318.0",
         "pyyaml>=5.4",  # TODO: remove when migrating to dbt 1.3
     ],
     zip_safe=False,

--- a/tests/functional/adapter/materialization/test_prepared_statements.py
+++ b/tests/functional/adapter/materialization/test_prepared_statements.py
@@ -72,11 +72,13 @@ class PreparedStatementsBase:
 
 
 @pytest.mark.prepared_statements_disabled
+@pytest.mark.skip_profile("starburst_galaxy")
 class TestPreparedStatementsDisabled(PreparedStatementsBase):
     def test_run_seed_with_prepared_statements_disabled(self, project, trino_connection):
         self.run_seed_with_prepared_statements(project, trino_connection, 0)
 
 
+@pytest.mark.skip_profile("starburst_galaxy")
 class TestPreparedStatementsEnabled(PreparedStatementsBase):
     def test_run_seed_with_prepared_statements_enabled(self, project, trino_connection):
         self.run_seed_with_prepared_statements(project, trino_connection, 1)


### PR DESCRIPTION
- Add version in 'source' connection parameter
- Fix CI
- Disable prepared_statement tests on Galaxy
- Unpin trino-python-client version