### PR TITLE
1.1.backport fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,13 @@ dbt-trino-tests:
 	./docker/dbt/build.sh
 	./docker/init_trino.bash
 	pip install -r dev_requirements.txt
-	tox -r  || ./docker/remove_trino.bash
+	tox -r
 	./docker/run_tests.bash
-	./docker/remove_trino.bash
 
 dbt-starburst-tests:
 	docker network create dbt-net || true
 	./docker/dbt/build.sh
 	./docker/init_starburst.bash
 	pip install -r dev_requirements.txt
-	tox -r || ./docker/remove_starburst.bash
+	tox -r
 	./docker/run_tests.bash
-	./docker/remove_starburst.bash

--- a/dbt/adapters/trino/connections.py
+++ b/dbt/adapters/trino/connections.py
@@ -19,6 +19,7 @@ import trino
 from trino.transaction import IsolationLevel
 import sqlparse
 
+from dbt.adapters.trino.__version__ import version
 
 logger = AdapterLogger("Trino")
 PREPARED_STATEMENTS_ENABLED_DEFAULT = True
@@ -379,7 +380,7 @@ class TrinoConnectionManager(SQLConnectionManager):
             session_properties=credentials.session_properties.copy(),
             auth=credentials.trino_auth(),
             isolation_level=IsolationLevel.AUTOCOMMIT,
-            source="dbt-trino",
+            source=f"dbt-trino-{version}",
         )
         trino_conn._http_session.verify = credentials.cert
         connection.state = "open"

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,6 @@ setup(
     },
     install_requires=[
         "dbt-core~={}".format(dbt_version),
-        "trino==0.313.0",
+        "trino~=0.313.0",
     ],
 )

--- a/tests/functional/adapter/materialization/test_prepared_statements.py
+++ b/tests/functional/adapter/materialization/test_prepared_statements.py
@@ -64,11 +64,13 @@ class PreparedStatementsBase:
         check_relations_equal(project.adapter, ["seed", "materialization"])
 
 @pytest.mark.prepared_statements_disabled
+@pytest.mark.skip_profile("starburst_galaxy")
 class TestPreparedStatementsDisabled(PreparedStatementsBase):
     def test_run_seed_with_prepared_statements_disabled(self, project, trino_connection):
         self.run_seed_with_prepared_statements(project, trino_connection, 0)
 
 
+@pytest.mark.skip_profile("starburst_galaxy")
 class TestPreparedStatementsEnabled(PreparedStatementsBase):
     def test_run_seed_with_prepared_statements_enabled(self, project, trino_connection):
         self.run_seed_with_prepared_statements(project, trino_connection, 1)


### PR DESCRIPTION
- Add version in 'source' connection parameter
- Fix CI
- Disable prepared_statement tests on Galaxy
- Unpin trino-python-client version