### PR TITLE
Add query, query_id and rows_affected in adapter response

### DIFF
--- a/.changes/unreleased/Features-20230308-200949.yaml
+++ b/.changes/unreleased/Features-20230308-200949.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add query, query_id and rows_affected in adapter response
+time: 2023-03-08T20:09:49.516088+01:00
+custom:
+  Author: mdesmet aezomz louis-zhang-unity3d
+  Issue: "186"
+  PR: "262"

--- a/dbt/adapters/trino/connections.py
+++ b/dbt/adapters/trino/connections.py
@@ -373,6 +373,12 @@ class ConnectionWrapper(object):
             raise ValueError("Cannot escape {}".format(type(value)))
 
 
+@dataclass
+class TrinoAdapterResponse(AdapterResponse):
+    query: str = ""
+    query_id: str = ""
+
+
 class TrinoConnectionManager(SQLConnectionManager):
     TYPE = "trino"
 
@@ -444,9 +450,14 @@ class TrinoConnectionManager(SQLConnectionManager):
         return connection
 
     @classmethod
-    def get_response(cls, cursor) -> AdapterResponse:
+    def get_response(cls, cursor) -> TrinoAdapterResponse:
         message = "SUCCESS"
-        return AdapterResponse(_message=message)
+        return TrinoAdapterResponse(
+            _message=message,
+            query=cursor._cursor.query,
+            query_id=cursor._cursor.query_id,
+            rows_affected=cursor._cursor.rowcount,
+        )  # type: ignore
 
     def cancel(self, connection):
         connection.handle.cancel()

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     },
     install_requires=[
         "dbt-core~={}".format(dbt_version),
-        "trino==0.321.0",
+        "trino~=0.322",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
## Overview

resolves #186, #210

## Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] `README.md` updated and added information about my change
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
