### PR TITLE
Fix issue #272

### DIFF
--- a/.changes/unreleased/Fixes-20230322-140501.yaml
+++ b/.changes/unreleased/Fixes-20230322-140501.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix performance issue with dbt docs generate
+time: 2023-03-22T14:05:01.364144523+01:00
+custom:
+  Author: Migi
+  Issue: "272"
+  PR: "273"

--- a/dbt/include/trino/macros/catalog.sql
+++ b/dbt/include/trino/macros/catalog.sql
@@ -38,7 +38,7 @@
         ),
 
         table_comment as (
-
+            {%- for schema in schemas %}
             select
                 catalog_name as "table_database",
                 schema_name as "table_schema",
@@ -51,7 +51,11 @@
                 and
                 schema_name != 'information_schema'
                 and
-                schema_name in ('{{ schemas | join("','") | lower }}')
+                schema_name = '{{ schema | lower }}'
+            {% if not loop.last %}
+            union all
+            {% endif %}
+            {%- endfor %}
         )
 
         select *


### PR DESCRIPTION
## Overview

Fixes issue #272.

This PR rewrites the `trino__get_catalog` macro so that instead of using
```sql
select ... from system.metadata.table_comments where ... and schema_name in ('schema_1', 'schema_2', etc)
```
 it uses `UNION ALL` to join subqueries which filter on one schema each, as follows:
```
select ... from system.metadata.table_comments where ... and schema_name = 'schema_1'
union all
select ... from system.metadata.table_comments where ... and schema_name = 'schema_2'
union all
etc.
```
By doing this, Trino reads only the table comments from the tables in the selected schemas instead of reading table comments from all tables in the catalog, which can be very slow.

With this change, running `dbt docs generate` is much faster, taking only a few seconds if the dbt project only contains a few tables. The affected query takes less than a second.

## Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change - seems not necessary
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
