### PR TITLE
Bump dependencies versions

### DIFF
--- a/.changes/unreleased/Dependencies-20230406-155907.yaml
+++ b/.changes/unreleased/Dependencies-20230406-155907.yaml
@@ -1,0 +1,7 @@
+kind: Dependencies
+body: Bump black from 22.12.0 to 23.3.0
+time: 2023-04-06T15:59:07.829542+02:00
+custom:
+  Author: damian3031
+  Issue: ""
+  PR: "277"

--- a/.changes/unreleased/Dependencies-20230406-160125.yaml
+++ b/.changes/unreleased/Dependencies-20230406-160125.yaml
@@ -1,0 +1,7 @@
+kind: Dependencies
+body: Bump flake8 from 5.0.4 to 6.0.0
+time: 2023-04-06T16:01:25.379068+02:00
+custom:
+  Author: damian3031
+  Issue: ""
+  PR: "277"

--- a/.changes/unreleased/Dependencies-20230406-160407.yaml
+++ b/.changes/unreleased/Dependencies-20230406-160407.yaml
@@ -1,0 +1,7 @@
+kind: Dependencies
+body: Bump tox from 3.27.1 to 4.4
+time: 2023-04-06T16:04:07.579674+02:00
+custom:
+  Author: damian3031
+  Issue: ""
+  PR: "277"

--- a/.changes/unreleased/Dependencies-20230406-160756.yaml
+++ b/.changes/unreleased/Dependencies-20230406-160756.yaml
@@ -1,0 +1,7 @@
+kind: Dependencies
+body: Add compatibility pin for dependencies. Remove obsolete ones.
+time: 2023-04-06T16:07:56.968787+02:00
+custom:
+  Author: damian3031
+  Issue: ""
+  PR: "277"

--- a/.changes/unreleased/Dependencies-20230407-110511.yaml
+++ b/.changes/unreleased/Dependencies-20230407-110511.yaml
@@ -1,0 +1,7 @@
+kind: Dependencies
+body: Bump mypy from 1.1.1 to 1.2.0
+time: 2023-04-07T11:05:11.255362+02:00
+custom:
+  Author: damian3031
+  Issue: ""
+  PR: "277"

--- a/.flake8
+++ b/.flake8
@@ -4,9 +4,9 @@ select =
     W
     F
 ignore =
-    W503 # makes Flake8 work like black
-    W504
-    E203 # makes Flake8 work like black
-    E741
-    E501
+    W503,
+    W504,
+    E203,
+    E741,
+    E501,
 exclude = test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
         alias: flake8-check
         stages: [manual]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.2.0
     hooks:
       - id: mypy
         # N.B.: Mypy is... a bit fragile.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - "markdown"
       - id: check-case-conflict
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.3.0
     hooks:
       - id: black
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       - id: isort
         args: [ "--profile", "black", "--filter-files" ]
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
       - id: flake8

--- a/dbt/adapters/trino/connections.py
+++ b/dbt/adapters/trino/connections.py
@@ -463,7 +463,6 @@ class TrinoConnectionManager(SQLConnectionManager):
         connection.handle.cancel()
 
     def add_query(self, sql, auto_begin=True, bindings=None, abridge_sql_log=False):
-
         connection = None
         cursor = None
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 dbt-tests-adapter~=1.4.5
-mypy==1.1.1  # patch updates have historically introduced breaking changes
+mypy==1.2.0  # patch updates have historically introduced breaking changes
 pre-commit~=3.2
 pytest~=7.2
 tox~=4.4

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,15 +1,5 @@
-black==22.12.0
-dbt-tests-adapter==1.4.5
-flake8>=3.5.0
-flaky>=3.5.3,<4
-freezegun==1.2.2
-ipdb
-isort
-mypy==1.1.1
-pre-commit
-pytest
-pytest-xdist>=2.1.0,<4
-pytz
+dbt-tests-adapter~=1.4.5
+mypy==1.1.1  # patch updates have historically introduced breaking changes
+pre-commit~=3.2
+pytest~=7.2
 tox~=4.4
-twine
-wheel

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -10,6 +10,6 @@ pre-commit
 pytest
 pytest-xdist>=2.1.0,<4
 pytz
-tox==3.27.1
+tox~=4.4
 twine
 wheel

--- a/tests/functional/adapter/test_session_property.py
+++ b/tests/functional/adapter/test_session_property.py
@@ -31,7 +31,6 @@ class TestSessionProperty:
         return {"session_property_model.sql": self.session_property_model(set_session_property)}
 
     def test_custom_schema_trino(self, project):
-
         # Run models.
         results = run_dbt(["run"], expect_pass=True)
         assert len(results) == 1

--- a/tox.ini
+++ b/tox.ini
@@ -3,17 +3,19 @@ skipsdist = True
 envlist = unit, integration
 
 [testenv:unit]
+description = unit testing
 basepython = python3
-commands = /bin/bash -c '{envpython} -m pytest -v {posargs} tests/unit'
+commands = {envpython} -m pytest -v {posargs} tests/unit
 passenv = DBT_INVOCATION_ENV
 deps =
     -r{toxinidir}/dev_requirements.txt
     -e.
 
 [testenv:integration]
+description = adapter plugin integration testing
 basepython = python3
-commands = /bin/bash -c '{envpython} -m pytest tests/functional'
-passenv = DBT_INVOCATION_ENV DBT_TEST_TRINO_HOST DBT_TEST_USER_1 DBT_TEST_USER_2 DBT_TEST_USER_3
+commands = {envpython} -m pytest {posargs} tests/functional
+passenv = DBT_INVOCATION_ENV, DBT_TEST_TRINO_HOST, DBT_TEST_USER_1, DBT_TEST_USER_2, DBT_TEST_USER_3
 deps =
     -r{toxinidir}/dev_requirements.txt
     -e.


### PR DESCRIPTION
1. Bumped versions of black, flake8, tox, with necessary other files adjustments.
2. Cleaned up `dev_requirements.txt`
	- removed not used packages,
	- removed packages which are used by pre-commit, as pre-commit creates its own environment for it hooks, 
	- added compatibility pin for every package