### PR TITLE
Bumping version to 1.5.0rc2, Add model contracts

### DIFF
--- a/.changes/unreleased/Features-20230419-115208.yaml
+++ b/.changes/unreleased/Features-20230419-115208.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add model contracts
+time: 2023-04-19T11:52:08.343309+02:00
+custom:
+  Author: damian3031
+  Issue: "284"
+  PR: "286"

--- a/dbt/adapters/trino/__version__.py
+++ b/dbt/adapters/trino/__version__.py
@@ -1,1 +1,1 @@
-version = "1.5.0rc1"
+version = "1.5.0rc2"

--- a/dbt/adapters/trino/__version__.py
+++ b/dbt/adapters/trino/__version__.py
@@ -1,1 +1,1 @@
-version = "1.4.2"
+version = "1.5.0rc1"

--- a/dbt/adapters/trino/connections.py
+++ b/dbt/adapters/trino/connections.py
@@ -508,3 +508,7 @@ class TrinoConnectionManager(SQLConnectionManager):
         status = self.get_response(cursor)
         table = self.get_result_from_cursor(cursor)
         return status, table
+
+    @classmethod
+    def data_type_code_to_name(cls, type_code) -> str:
+        return type_code.split("(")[0].upper()

--- a/dbt/adapters/trino/impl.py
+++ b/dbt/adapters/trino/impl.py
@@ -24,7 +24,7 @@ class TrinoAdapter(SQLAdapter):
 
     CONSTRAINT_SUPPORT = {
         ConstraintType.check: ConstraintSupport.NOT_SUPPORTED,
-        ConstraintType.not_null: ConstraintSupport.NOT_SUPPORTED,
+        ConstraintType.not_null: ConstraintSupport.ENFORCED,
         ConstraintType.unique: ConstraintSupport.NOT_SUPPORTED,
         ConstraintType.primary_key: ConstraintSupport.NOT_SUPPORTED,
         ConstraintType.foreign_key: ConstraintSupport.NOT_SUPPORTED,

--- a/dbt/adapters/trino/impl.py
+++ b/dbt/adapters/trino/impl.py
@@ -2,8 +2,9 @@ from dataclasses import dataclass
 from typing import Dict, Optional
 
 import agate
-from dbt.adapters.base.impl import AdapterConfig
+from dbt.adapters.base.impl import AdapterConfig, ConstraintSupport
 from dbt.adapters.sql import SQLAdapter
+from dbt.contracts.graph.nodes import ConstraintType
 from dbt.exceptions import DbtDatabaseError
 
 from dbt.adapters.trino import TrinoColumn, TrinoConnectionManager, TrinoRelation
@@ -20,6 +21,14 @@ class TrinoAdapter(SQLAdapter):
     Column = TrinoColumn
     ConnectionManager = TrinoConnectionManager
     AdapterSpecificConfigs = TrinoConfig
+
+    CONSTRAINT_SUPPORT = {
+        ConstraintType.check: ConstraintSupport.NOT_SUPPORTED,
+        ConstraintType.not_null: ConstraintSupport.NOT_SUPPORTED,
+        ConstraintType.unique: ConstraintSupport.NOT_SUPPORTED,
+        ConstraintType.primary_key: ConstraintSupport.NOT_SUPPORTED,
+        ConstraintType.foreign_key: ConstraintSupport.NOT_SUPPORTED,
+    }
 
     @classmethod
     def date_function(cls):

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-dbt-tests-adapter~=1.4.5
+dbt-tests-adapter~=1.5.0rc1
 mypy==1.2.0  # patch updates have historically introduced breaking changes
 pre-commit~=3.2
 pytest~=7.2

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-dbt-tests-adapter~=1.5.0rc1
+dbt-tests-adapter~=1.5.0rc2
 mypy==1.2.0  # patch updates have historically introduced breaking changes
 pre-commit~=3.2
 pytest~=7.2

--- a/tests/functional/adapter/constraints/fixtures.py
+++ b/tests/functional/adapter/constraints/fixtures.py
@@ -1,0 +1,119 @@
+# model breaking constraints
+trino_model_char_value_to_int_column = """
+{{
+  config(
+    materialized = "table"
+  )
+}}
+
+select
+  -- char value for 'id', which is integer type
+  'char_value' as id,
+  -- change the color as well (to test rollback)
+  'red' as color,
+  '2019-01-01' as date_day
+"""
+
+trino_model_schema_yml = """
+version: 2
+models:
+  - name: my_model
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        quote: true
+        data_type: integer
+        description: hello
+        constraints:
+          - type: check
+            expression: (id > 0)
+        tests:
+          - unique
+      - name: color
+        data_type: varchar
+      - name: date_day
+        data_type: varchar
+  - name: my_model_error
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: integer
+        description: hello
+        constraints:
+          - type: check
+            expression: (id > 0)
+        tests:
+          - unique
+      - name: color
+        data_type: varchar
+      - name: date_day
+        data_type: varchar
+  - name: my_model_wrong_order
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: integer
+        description: hello
+        constraints:
+          - type: check
+            expression: (id > 0)
+        tests:
+          - unique
+      - name: color
+        data_type: varchar
+      - name: date_day
+        data_type: varchar
+  - name: my_model_wrong_name
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: integer
+        description: hello
+        constraints:
+          - type: check
+            expression: (id > 0)
+        tests:
+          - unique
+      - name: color
+        data_type: varchar
+      - name: date_day
+        data_type: varchar
+"""
+
+trino_constrained_model_schema_yml = """
+version: 2
+models:
+  - name: my_model
+    config:
+      contract:
+        enforced: true
+    constraints:
+      - type: check
+        expression: (id > 0)
+      - type: primary_key
+        columns: [ id ]
+      - type: unique
+        columns: [ color, date_day ]
+        name: strange_uniqueness_requirement
+    columns:
+      - name: id
+        quote: true
+        data_type: integer
+        description: hello
+        constraints:
+          - type: not_null
+        tests:
+          - unique
+      - name: color
+        data_type: varchar
+      - name: date_day
+        data_type: varchar
+"""

--- a/tests/functional/adapter/constraints/fixtures.py
+++ b/tests/functional/adapter/constraints/fixtures.py
@@ -1,19 +1,3 @@
-# model breaking constraints
-trino_model_char_value_to_int_column = """
-{{
-  config(
-    materialized = "table"
-  )
-}}
-
-select
-  -- char value for 'id', which is integer type
-  'char_value' as id,
-  -- change the color as well (to test rollback)
-  'red' as color,
-  '2019-01-01' as date_day
-"""
-
 trino_model_schema_yml = """
 version: 2
 models:
@@ -27,6 +11,7 @@ models:
         data_type: integer
         description: hello
         constraints:
+          - type: not_null
           - type: check
             expression: (id > 0)
         tests:
@@ -44,6 +29,7 @@ models:
         data_type: integer
         description: hello
         constraints:
+          - type: not_null
           - type: check
             expression: (id > 0)
         tests:
@@ -61,6 +47,7 @@ models:
         data_type: integer
         description: hello
         constraints:
+          - type: not_null
           - type: check
             expression: (id > 0)
         tests:
@@ -78,6 +65,7 @@ models:
         data_type: integer
         description: hello
         constraints:
+          - type: not_null
           - type: check
             expression: (id > 0)
         tests:

--- a/tests/functional/adapter/constraints/test_constraints.py
+++ b/tests/functional/adapter/constraints/test_constraints.py
@@ -22,13 +22,12 @@ from dbt.tests.adapter.constraints.test_constraints import (
 
 from tests.functional.adapter.constraints.fixtures import (
     trino_constrained_model_schema_yml,
-    trino_model_char_value_to_int_column,
     trino_model_schema_yml,
 )
 
 _expected_sql_trino = """
 create table <model_identifier> (
-    id integer,
+    id integer not null,
     color varchar,
     date_day varchar
 ) ;
@@ -74,6 +73,7 @@ class TrinoColumnEqualSetup:
         ]
 
 
+@pytest.mark.iceberg
 class TestTrinoTableConstraintsColumnsEqual(
     TrinoColumnEqualSetup, BaseTableConstraintsColumnsEqual
 ):
@@ -96,6 +96,7 @@ class TestTrinoViewConstraintsColumnsEqual(TrinoColumnEqualSetup, BaseViewConstr
         }
 
 
+@pytest.mark.iceberg
 class TestTrinoIncrementalConstraintsColumnsEqual(
     TrinoColumnEqualSetup, BaseIncrementalConstraintsColumnsEqual
 ):
@@ -108,6 +109,7 @@ class TestTrinoIncrementalConstraintsColumnsEqual(
         }
 
 
+@pytest.mark.iceberg
 class TestTrinoTableConstraintsRuntimeDdlEnforcement(BaseConstraintsRuntimeDdlEnforcement):
     @pytest.fixture(scope="class")
     def models(self):
@@ -121,6 +123,7 @@ class TestTrinoTableConstraintsRuntimeDdlEnforcement(BaseConstraintsRuntimeDdlEn
         return _expected_sql_trino
 
 
+@pytest.mark.iceberg
 class TestTrinoTableConstraintsRollback(BaseConstraintsRollback):
     @pytest.fixture(scope="class")
     def models(self):
@@ -129,20 +132,12 @@ class TestTrinoTableConstraintsRollback(BaseConstraintsRollback):
             "constraints_schema.yml": trino_model_schema_yml,
         }
 
-    # We are trying to load char value to integer column to break constraint.
-    # In BaseConstraintsRollback it is checked by violating not-null constraint,
-    # But not-null constraint is not supported in dbt-trino
-    @pytest.fixture(scope="class")
-    def null_model_sql(self):
-        return trino_model_char_value_to_int_column
-
     @pytest.fixture(scope="class")
     def expected_error_messages(self):
-        return [
-            "Please ensure the name, data_type, and number of columns in your contract match the columns in your model's definition."
-        ]
+        return ["NULL value not allowed for NOT NULL column: id"]
 
 
+@pytest.mark.iceberg
 class TestTrinoIncrementalConstraintsRuntimeDdlEnforcement(
     BaseIncrementalConstraintsRuntimeDdlEnforcement
 ):
@@ -158,6 +153,7 @@ class TestTrinoIncrementalConstraintsRuntimeDdlEnforcement(
         return _expected_sql_trino
 
 
+@pytest.mark.iceberg
 class TestTrinoIncrementalConstraintsRollback(BaseIncrementalConstraintsRollback):
     @pytest.fixture(scope="class")
     def models(self):
@@ -166,20 +162,12 @@ class TestTrinoIncrementalConstraintsRollback(BaseIncrementalConstraintsRollback
             "constraints_schema.yml": trino_model_schema_yml,
         }
 
-    # We are trying to load char value to integer column to break constraint.
-    # In BaseConstraintsRollback it is checked by violating not-null constraint,
-    # But not-null constraint is not supported in dbt-trino
-    @pytest.fixture(scope="class")
-    def null_model_sql(self):
-        return trino_model_char_value_to_int_column
-
     @pytest.fixture(scope="class")
     def expected_error_messages(self):
-        return [
-            "Please ensure the name, data_type, and number of columns in your contract match the columns in your model's definition."
-        ]
+        return ["NULL value not allowed for NOT NULL column: id"]
 
 
+@pytest.mark.iceberg
 class TestTrinoModelConstraintsRuntimeEnforcement(BaseModelConstraintsRuntimeEnforcement):
     @pytest.fixture(scope="class")
     def models(self):
@@ -192,7 +180,7 @@ class TestTrinoModelConstraintsRuntimeEnforcement(BaseModelConstraintsRuntimeEnf
     def expected_sql(self):
         return """
 create table <model_identifier> (
-    id integer,
+    id integer not null,
     color varchar,
     date_day varchar
 ) ;

--- a/tests/functional/adapter/constraints/test_constraints.py
+++ b/tests/functional/adapter/constraints/test_constraints.py
@@ -1,0 +1,213 @@
+import pytest
+from dbt.tests.adapter.constraints.fixtures import (
+    my_incremental_model_sql,
+    my_model_incremental_wrong_name_sql,
+    my_model_incremental_wrong_order_sql,
+    my_model_sql,
+    my_model_view_wrong_name_sql,
+    my_model_view_wrong_order_sql,
+    my_model_wrong_name_sql,
+    my_model_wrong_order_sql,
+)
+from dbt.tests.adapter.constraints.test_constraints import (
+    BaseConstraintsRollback,
+    BaseConstraintsRuntimeDdlEnforcement,
+    BaseIncrementalConstraintsColumnsEqual,
+    BaseIncrementalConstraintsRollback,
+    BaseIncrementalConstraintsRuntimeDdlEnforcement,
+    BaseModelConstraintsRuntimeEnforcement,
+    BaseTableConstraintsColumnsEqual,
+    BaseViewConstraintsColumnsEqual,
+)
+
+from tests.functional.adapter.constraints.fixtures import (
+    trino_constrained_model_schema_yml,
+    trino_model_char_value_to_int_column,
+    trino_model_schema_yml,
+)
+
+_expected_sql_trino = """
+create table <model_identifier> (
+    id integer,
+    color varchar,
+    date_day varchar
+) ;
+insert into <model_identifier>
+(
+    select
+        id,
+        color,
+        date_day from
+    (
+        select
+            'blue' as color,
+            1 as id,
+            '2019-01-01' as date_day
+    ) as model_subq
+)
+;
+"""
+
+
+class TrinoColumnEqualSetup:
+    @pytest.fixture
+    def string_type(self):
+        return "VARCHAR"
+
+    @pytest.fixture
+    def data_types(self, schema_int_type, int_type, string_type):
+        # sql_column_value, schema_data_type, error_data_type
+        return [
+            ["1", schema_int_type, int_type],
+            ["'1'", string_type, string_type],
+            ["cast('2019-01-01' as date)", "date", "DATE"],
+            ["true", "boolean", "BOOLEAN"],
+            ["cast('2013-11-03 00:00:00-07' as TIMESTAMP)", "timestamp(6)", "TIMESTAMP"],
+            [
+                "cast('2013-11-03 00:00:00-07' as TIMESTAMP WITH TIME ZONE)",
+                "timestamp(6)",
+                "TIMESTAMP",
+            ],
+            ["ARRAY['a','b','c']", "ARRAY(VARCHAR)", "ARRAY"],
+            ["ARRAY[1,2,3]", "ARRAY(INTEGER)", "ARRAY"],
+            ["cast('1' as DECIMAL)", "DECIMAL", "DECIMAL"],
+        ]
+
+
+class TestTrinoTableConstraintsColumnsEqual(
+    TrinoColumnEqualSetup, BaseTableConstraintsColumnsEqual
+):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_wrong_order.sql": my_model_wrong_order_sql,
+            "my_model_wrong_name.sql": my_model_wrong_name_sql,
+            "constraints_schema.yml": trino_model_schema_yml,
+        }
+
+
+class TestTrinoViewConstraintsColumnsEqual(TrinoColumnEqualSetup, BaseViewConstraintsColumnsEqual):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_wrong_order.sql": my_model_view_wrong_order_sql,
+            "my_model_wrong_name.sql": my_model_view_wrong_name_sql,
+            "constraints_schema.yml": trino_model_schema_yml,
+        }
+
+
+class TestTrinoIncrementalConstraintsColumnsEqual(
+    TrinoColumnEqualSetup, BaseIncrementalConstraintsColumnsEqual
+):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_wrong_order.sql": my_model_incremental_wrong_order_sql,
+            "my_model_wrong_name.sql": my_model_incremental_wrong_name_sql,
+            "constraints_schema.yml": trino_model_schema_yml,
+        }
+
+
+class TestTrinoTableConstraintsRuntimeDdlEnforcement(BaseConstraintsRuntimeDdlEnforcement):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_wrong_order_sql,
+            "constraints_schema.yml": trino_model_schema_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def expected_sql(self):
+        return _expected_sql_trino
+
+
+class TestTrinoTableConstraintsRollback(BaseConstraintsRollback):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "constraints_schema.yml": trino_model_schema_yml,
+        }
+
+    # We are trying to load char value to integer column to break constraint.
+    # In BaseConstraintsRollback it is checked by violating not-null constraint,
+    # But not-null constraint is not supported in dbt-trino
+    @pytest.fixture(scope="class")
+    def null_model_sql(self):
+        return trino_model_char_value_to_int_column
+
+    @pytest.fixture(scope="class")
+    def expected_error_messages(self):
+        return [
+            "Please ensure the name, data_type, and number of columns in your contract match the columns in your model's definition."
+        ]
+
+
+class TestTrinoIncrementalConstraintsRuntimeDdlEnforcement(
+    BaseIncrementalConstraintsRuntimeDdlEnforcement
+):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_incremental_wrong_order_sql,
+            "constraints_schema.yml": trino_model_schema_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def expected_sql(self):
+        return _expected_sql_trino
+
+
+class TestTrinoIncrementalConstraintsRollback(BaseIncrementalConstraintsRollback):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_incremental_model_sql,
+            "constraints_schema.yml": trino_model_schema_yml,
+        }
+
+    # We are trying to load char value to integer column to break constraint.
+    # In BaseConstraintsRollback it is checked by violating not-null constraint,
+    # But not-null constraint is not supported in dbt-trino
+    @pytest.fixture(scope="class")
+    def null_model_sql(self):
+        return trino_model_char_value_to_int_column
+
+    @pytest.fixture(scope="class")
+    def expected_error_messages(self):
+        return [
+            "Please ensure the name, data_type, and number of columns in your contract match the columns in your model's definition."
+        ]
+
+
+class TestTrinoModelConstraintsRuntimeEnforcement(BaseModelConstraintsRuntimeEnforcement):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "constraints_schema.yml": trino_constrained_model_schema_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def expected_sql(self):
+        return """
+create table <model_identifier> (
+    id integer,
+    color varchar,
+    date_day varchar
+) ;
+insert into <model_identifier>
+(
+    select
+        id,
+        color,
+        date_day from
+    (
+        select
+            1 as id,
+            'blue' as color,
+            '2019-01-01' as date_day
+    ) as model_subq
+)
+;
+"""

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -43,6 +43,14 @@ def profile_from_dict(profile, profile_name, cli_vars="{}"):
         cli_vars = parse_cli_vars(cli_vars)
 
     renderer = ProfileRenderer(cli_vars)
+
+    # in order to call dbt's internal profile rendering, we need to set the
+    # flags global. This is a bit of a hack, but it's the best way to do it.
+    from argparse import Namespace
+
+    from dbt.flags import set_from_args
+
+    set_from_args(Namespace(), None)
     return Profile.from_raw_profile_info(
         profile,
         profile_name,
@@ -74,6 +82,10 @@ def config_from_parts_or_dicts(project, profile, packages=None, selectors=None, 
     from copy import deepcopy
 
     from dbt.config import Profile, Project, RuntimeConfig
+    from dbt.config.utils import parse_cli_vars
+
+    if not isinstance(cli_vars, dict):
+        cli_vars = parse_cli_vars(cli_vars)
 
     if isinstance(project, Project):
         profile_name = project.profile_name


### PR DESCRIPTION
This PR is about:
1. Bumping dbt-core version to 1.5.0rc1
2. Implementing [model contracts](https://docs.getdbt.com/docs/collaborate/govern/model-contracts) (new functionality in v1.5.)
(High level explanation of these changes in [this discussion](https://github.com/dbt-labs/dbt-core/discussions/7213) under `Model Contracts` section)

Some remarks about model contracts implementation:

1. It is implemented by running 2 queries: `Create table` and `Insert into` (similar as in dbt-redshift - [example query](https://github.com/dbt-labs/dbt-redshift/blob/v1.5.0rc1/tests/functional/adapter/test_constraints.py#L13-L33)).
It couldn't be implemeted as single CTAS query (as in dbt-snowflake - [example query](https://github.com/dbt-labs/dbt-snowflake/blob/v1.5.0rc1/tests/functional/adapter/test_constraints.py#L15-L31)), as in Trino we can't
define column types in CTAS query.

2. dbt-core model contracts works on enforcing column names and types in table, and columns constraints:
`not null`, `unique`, `primary key`, `foreign key`, `check`
Trino doesn't support any of them, except that `not null` is supported in some connectors.

	It is a tricky one, as `not null` is supported in some connectors, but it isn't in others (memory, hive).
It isn't documented in Trino docs (it isn't explicitly mentioned in connector page - [hive connector docs](https://trino.io/docs/current/connector/hive.html), nor in [CREATE TABLE docs](https://trino.io/docs/current/sql/create-table.html))
So I'm not sure if we should support it now, as user would ask questions why it's not working with
'X' catalog, when we can't point them directly to connector documentation.

Please let me know what you think.

