### PR TITLE
Add new tests from dbt-tests-adapter 1.5

### DIFF
--- a/.changes/unreleased/Under the Hood-20230424-163631.yaml
+++ b/.changes/unreleased/Under the Hood-20230424-163631.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Add new tests from dbt-tests-adapter 1.5
+time: 2023-04-24T16:36:31.991179+02:00
+custom:
+  Author: damian3031
+  Issue: "284"
+  PR: "289"

--- a/.changes/unreleased/Under the Hood-20230424-163815.yaml
+++ b/.changes/unreleased/Under the Hood-20230424-163815.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Added columns types checking methods for Trino
+time: 2023-04-24T16:38:15.069495+02:00
+custom:
+  Author: damian3031
+  Issue: "284"
+  PR: "289"

--- a/dbt/adapters/trino/column.py
+++ b/dbt/adapters/trino/column.py
@@ -28,6 +28,28 @@ class TrinoColumn(Column):
 
         return super().data_type
 
+    def is_string(self) -> bool:
+        return self.dtype.lower() in ["varchar", "char", "varbinary", "json"]
+
+    def is_float(self) -> bool:
+        return self.dtype.lower() in [
+            "real",
+            "double precision",
+            "double",
+        ]
+
+    def is_integer(self) -> bool:
+        return self.dtype.lower() in [
+            "tinyint",
+            "smallint",
+            "integer",
+            "int",
+            "bigint",
+        ]
+
+    def is_numeric(self) -> bool:
+        return self.dtype.lower() == "decimal"
+
     @classmethod
     def string_type(cls, size: int) -> str:
         return "varchar({})".format(size)

--- a/tests/functional/adapter/column_types/fixtures.py
+++ b/tests/functional/adapter/column_types/fixtures.py
@@ -1,0 +1,38 @@
+model_sql = """
+select
+    cast(0 as tinyint) as tinyint_col,
+    cast(1 as smallint) as smallint_col,
+    cast(2 as integer) as integer_col,
+    cast(2 as int) as int_col,
+    cast(3 as bigint) as bigint_col,
+    cast(4.0 as real) as real_col,
+    cast(5.0 as double) as double_col,
+    cast(5.5 as double precision) as double_precision_col,
+    cast(6.0 as decimal) as decimal_col,
+    cast('7' as char) as char_col,
+    cast('8' as varchar(20)) as varchar_col,
+    cast(X'65683F' as varbinary) as varbinary_col,
+    cast('{"k1":1,"k2":23,"k3":456}' as json) as json_col
+"""
+
+schema_yml = """
+version: 2
+models:
+  - name: model
+    tests:
+      - is_type:
+          column_map:
+            tinyint_col: ['integer', 'number']
+            smallint_col: ['integer', 'number']
+            integer_col: ['integer', 'number']
+            int_col: ['integer', 'number']
+            bigint_col: ['integer', 'number']
+            real_col: ['float', 'number']
+            double_col: ['float', 'number']
+            double_precision_col: ['float', 'number']
+            decimal_col: ['numeric', 'number']
+            char_col: ['string', 'not number']
+            varchar_col: ['string', 'not number']
+            varbinary_col: ['string', 'not number']
+            json_col: ['string', 'not number']
+"""

--- a/tests/functional/adapter/column_types/test_column_types.py
+++ b/tests/functional/adapter/column_types/test_column_types.py
@@ -1,0 +1,13 @@
+import pytest
+from dbt.tests.adapter.column_types.test_column_types import BaseColumnTypes
+
+from tests.functional.adapter.column_types.fixtures import model_sql, schema_yml
+
+
+class TestTrinoColumnTypes(BaseColumnTypes):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model.sql": model_sql, "schema.yml": schema_yml}
+
+    def test_run_and_test(self, project):
+        self.run_and_test()

--- a/tests/functional/adapter/hooks/data/seed_model.sql
+++ b/tests/functional/adapter/hooks/data/seed_model.sql
@@ -1,0 +1,15 @@
+drop table if exists {schema}.on_model_hook;
+
+create table {schema}.on_model_hook (
+    test_state       VARCHAR, -- start|end
+    target_dbname    VARCHAR,
+    target_host      VARCHAR,
+    target_name      VARCHAR,
+    target_schema    VARCHAR,
+    target_type      VARCHAR,
+    target_user      VARCHAR,
+    target_pass      VARCHAR,
+    target_threads   INTEGER,
+    run_started_at   VARCHAR,
+    invocation_id    VARCHAR
+);

--- a/tests/functional/adapter/hooks/data/seed_run.sql
+++ b/tests/functional/adapter/hooks/data/seed_run.sql
@@ -1,0 +1,15 @@
+drop table if exists {schema}.on_run_hook;
+
+create table {schema}.on_run_hook (
+    test_state       VARCHAR, -- start|end
+    target_dbname    VARCHAR,
+    target_host      VARCHAR,
+    target_name      VARCHAR,
+    target_schema    VARCHAR,
+    target_type      VARCHAR,
+    target_user      VARCHAR,
+    target_pass      VARCHAR,
+    target_threads   INTEGER,
+    run_started_at   VARCHAR,
+    invocation_id    VARCHAR
+);

--- a/tests/functional/adapter/hooks/test_model_hooks.py
+++ b/tests/functional/adapter/hooks/test_model_hooks.py
@@ -1,0 +1,37 @@
+import pytest
+from dbt.tests.adapter.hooks import test_model_hooks as core_base
+
+
+class TestTrinoPrePostModelHooks(core_base.TestPrePostModelHooks):
+    def check_hooks(self, state, project, host, count=1):
+        self.get_ctx_vars(state, count=count, project=project)
+
+
+class TestTrinoPrePostModelHooksUnderscores(core_base.TestPrePostModelHooksUnderscores):
+    def check_hooks(self, state, project, host, count=1):
+        self.get_ctx_vars(state, count=count, project=project)
+
+
+class TestTrinoHookRefs(core_base.TestHookRefs):
+    def check_hooks(self, state, project, host, count=1):
+        self.get_ctx_vars(state, count=count, project=project)
+
+
+@pytest.mark.iceberg
+class TestTrinoPrePostModelHooksOnSeeds(core_base.TestPrePostModelHooksOnSeeds):
+    def check_hooks(self, state, project, host, count=1):
+        self.get_ctx_vars(state, count=count, project=project)
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "seed-paths": ["seeds"],
+            "models": {},
+            "seeds": {
+                "+post-hook": [
+                    "alter table {{ this }} add column new_col int",
+                    "update {{ this }} set new_col = 1 where 1=1",
+                ],
+                "quote_columns": True,
+            },
+        }

--- a/tests/functional/adapter/hooks/test_run_hooks.py
+++ b/tests/functional/adapter/hooks/test_run_hooks.py
@@ -1,0 +1,54 @@
+import pytest
+from dbt.tests.adapter.hooks import test_run_hooks as core_base
+
+
+class TestPrePostRunHooksTrino(core_base.TestPrePostRunHooks):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            # The create and drop table statements here validate that these hooks run
+            # in the same order that they are defined. Drop before create is an error.
+            # Also check that the table does not exist below.
+            "on-run-start": [
+                "{{ custom_run_hook('start', target, run_started_at, invocation_id) }}",
+                "create table {{ target.schema }}.start_hook_order_test ( id int )",
+                "drop table {{ target.schema }}.start_hook_order_test",
+                "{{ log(env_var('TERM_TEST'), info=True) }}",
+            ],
+            "on-run-end": [
+                "{{ custom_run_hook('end', target, run_started_at, invocation_id) }}",
+                "create table {{ target.schema }}.end_hook_order_test ( id int )",
+                "drop table {{ target.schema }}.end_hook_order_test",
+                "create table {{ target.schema }}.schemas ( schema varchar )",
+                "insert into {{ target.schema }}.schemas (schema) values {% for schema in schemas %}( '{{ schema }}' ){% if not loop.last %},{% endif %}{% endfor %}",
+                "create table {{ target.schema }}.db_schemas ( db varchar, schema varchar )",
+                "insert into {{ target.schema }}.db_schemas (db, schema) values {% for db, schema in database_schemas %}('{{ db }}', '{{ schema }}' ){% if not loop.last %},{% endif %}{% endfor %}",
+            ],
+            "seeds": {
+                "quote_columns": False,
+            },
+        }
+
+    def check_hooks(self, state, project, host):
+        ctx = self.get_ctx_vars(state, project)
+
+        assert ctx["test_state"] == state
+        assert ctx["target_dbname"] == ""
+        assert ctx["target_host"] == host
+        assert ctx["target_name"] == "default"
+        assert ctx["target_schema"] == project.test_schema
+        assert ctx["target_threads"] == 4
+        assert ctx["target_type"] == "trino"
+        assert ctx["target_user"] == "admin"
+        assert ctx["target_pass"] == ""
+
+        assert (
+            ctx["run_started_at"] is not None and len(ctx["run_started_at"]) > 0
+        ), "run_started_at was not set"
+        assert (
+            ctx["invocation_id"] is not None and len(ctx["invocation_id"]) > 0
+        ), "invocation_id was not set"
+
+
+class TestAfterRunHooksTrino(core_base.TestAfterRunHooks):
+    pass

--- a/tests/functional/adapter/persist_docs/test_persist_docs.py
+++ b/tests/functional/adapter/persist_docs/test_persist_docs.py
@@ -1,4 +1,9 @@
 import pytest
+from dbt.tests.adapter.persist_docs.test_persist_docs import (
+    BasePersistDocs,
+    BasePersistDocsColumnMissing,
+    BasePersistDocsCommentOnQuotedColumn,
+)
 from dbt.tests.util import run_dbt
 
 from tests.functional.adapter.persist_docs.fixtures import (
@@ -128,3 +133,15 @@ class TestPersistDocsIncremental(TestPersistDocsBase):
         # test tests
         results = run_dbt(["test"], expect_pass=True)
         assert len(results) == 4
+
+
+class TestPersistDocs(BasePersistDocs):
+    pass
+
+
+class TestPersistDocsColumnMissing(BasePersistDocsColumnMissing):
+    pass
+
+
+class TestPersistDocsCommentOnQuotedColumn(BasePersistDocsCommentOnQuotedColumn):
+    pass

--- a/tests/functional/adapter/test_caching.py
+++ b/tests/functional/adapter/test_caching.py
@@ -1,0 +1,17 @@
+from dbt.tests.adapter.caching.test_caching import (
+    BaseCachingLowercaseModel,
+    BaseCachingSelectedSchemaOnly,
+    BaseCachingUppercaseModel,
+)
+
+
+class TestCachingLowerCaseModel(BaseCachingLowercaseModel):
+    pass
+
+
+class TestCachingUppercaseModel(BaseCachingUppercaseModel):
+    pass
+
+
+class TestCachingSelectedSchemaOnly(BaseCachingSelectedSchemaOnly):
+    pass

--- a/tests/functional/adapter/test_simple_copy.py
+++ b/tests/functional/adapter/test_simple_copy.py
@@ -1,0 +1,42 @@
+import pytest
+from dbt.tests.adapter.simple_copy.test_simple_copy import (
+    EmptyModelsArentRunBase,
+    SimpleCopyBase,
+)
+from dbt.tests.util import run_dbt
+
+
+@pytest.mark.iceberg
+class TestSimpleCopyBase(SimpleCopyBase):
+    pass
+
+
+# Trino implementation of dbt.tests.fixtures.project.TestProjInfo.get_tables_in_schema
+# which use `like` instead of `ilike`
+def trino_get_tables_in_schema(prj):
+    sql = """
+            select table_name,
+                    case when table_type = 'BASE TABLE' then 'table'
+                         when table_type = 'VIEW' then 'view'
+                         else table_type
+                    end as materialization
+            from information_schema.tables
+            where {}
+            order by table_name
+            """
+    sql = sql.format("lower({}) like lower('{}')".format("table_schema", prj.test_schema))
+    result = prj.run_sql(sql, fetch="all")
+    return {model_name: materialization for (model_name, materialization) in result}
+
+
+class TestEmptyModelsArentRun(EmptyModelsArentRunBase):
+    def test_dbt_doesnt_run_empty_models(self, project):
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        results = run_dbt()
+        assert len(results) == 7
+
+        tables = trino_get_tables_in_schema(project)
+
+        assert "empty" not in tables.keys()
+        assert "disabled" not in tables.keys()

--- a/tests/functional/adapter/test_simple_snapshot.py
+++ b/tests/functional/adapter/test_simple_snapshot.py
@@ -1,0 +1,95 @@
+import pytest
+from dbt.tests.adapter.simple_snapshot.test_snapshot import (
+    BaseSimpleSnapshot,
+    BaseSnapshotCheck,
+)
+from dbt.tests.util import run_dbt
+
+iceberg_macro_override_sql = """
+{% macro trino__current_timestamp() -%}
+    current_timestamp(6)
+{%- endmacro %}
+"""
+
+
+class TrinoSimpleSnapshot(BaseSimpleSnapshot):
+    def test_updates_are_captured_by_snapshot(self, project):
+        """
+        Update the last 5 records. Show that all ids are current, but the last 5 reflect updates.
+        """
+        self.update_fact_records(
+            {"updated_at": "updated_at + interval '1' day"}, "id between 16 and 20"
+        )
+        run_dbt(["snapshot"])
+        self._assert_results(
+            ids_with_current_snapshot_records=range(1, 21),
+            ids_with_closed_out_snapshot_records=range(16, 21),
+        )
+
+    def test_new_column_captured_by_snapshot(self, project):
+        """
+        Add a column to `fact` and populate the last 10 records with a non-null value.
+        Show that all ids are current, but the last 10 reflect updates and the first 10 don't
+        i.e. if the column is added, but not updated, the record doesn't reflect that it's updated
+        """
+        self.add_fact_column("full_name", "varchar(200)")
+        self.update_fact_records(
+            {
+                "full_name": "first_name || ' ' || last_name",
+                "updated_at": "updated_at + interval '1' day",
+            },
+            "id between 11 and 20",
+        )
+        run_dbt(["snapshot"])
+        self._assert_results(
+            ids_with_current_snapshot_records=range(1, 21),
+            ids_with_closed_out_snapshot_records=range(11, 21),
+        )
+
+
+class TrinoSnapshotCheck(BaseSnapshotCheck):
+    def test_column_selection_is_reflected_in_snapshot(self, project):
+        """
+        Update the first 10 records on a non-tracked column.
+        Update the middle 10 records on a tracked column. (hence records 6-10 are updated on both)
+        Show that all ids are current, and only the tracked column updates are reflected in `snapshot`.
+        """
+        self.update_fact_records(
+            {"last_name": "substring(last_name, 1, 3)"}, "id between 1 and 10"
+        )  # not tracked
+        self.update_fact_records(
+            {"email": "substring(email, 1, 3)"}, "id between 6 and 15"
+        )  # tracked
+        run_dbt(["snapshot"])
+        self._assert_results(
+            ids_with_current_snapshot_records=range(1, 21),
+            ids_with_closed_out_snapshot_records=range(6, 16),
+        )
+
+
+@pytest.mark.iceberg
+class TestIcebergSimpleSnapshot(TrinoSimpleSnapshot):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "seeds": {
+                "+column_types": {"updated_at": "timestamp(6)"},
+            },
+        }
+
+
+@pytest.mark.delta
+class TestDeltaSimpleSnapshot(TrinoSimpleSnapshot):
+    pass
+
+
+@pytest.mark.iceberg
+class TestIcebergSnapshotCheck(TrinoSnapshotCheck):
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"iceberg.sql": iceberg_macro_override_sql}
+
+
+@pytest.mark.delta
+class TestDeltaSnapshotCheck(TrinoSnapshotCheck):
+    pass


### PR DESCRIPTION
Part of https://github.com/starburstdata/dbt-trino/issues/284
1. Added new tests from `dbt-tests-adapter` 1.5
2. Added Trino '_shims_' for methods `is_string`, `is_float`, `is_integer`, `is_numeric`