### PR TITLE
Set the table comment when creating the table

### DIFF
--- a/.changes/unreleased/Under the Hood-20230630-122950.yaml
+++ b/.changes/unreleased/Under the Hood-20230630-122950.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Set the table comment when creating the table
+time: 2023-06-30T12:29:50.043761+02:00
+custom:
+  Author: Fokko
+  Issue: "318"
+  PR: "317"

--- a/dbt/include/trino/macros/adapters.sql
+++ b/dbt/include/trino/macros/adapters.sql
@@ -88,6 +88,11 @@
   {%- endif -%}
 {%- endmacro -%}
 
+{% macro comment(comment) %}
+  {%- if comment is not none and comment|length > 0 -%}
+      comment '{{ comment | replace("'", "''") }}'
+  {%- endif -%}
+{%- endmacro -%}
 
 {% macro trino__create_table_as(temporary, relation, sql) -%}
   {%- set _properties = config.get('properties') -%}
@@ -100,6 +105,7 @@
     {{ get_table_columns_and_constraints() }}
     {{ get_assert_columns_equivalent(sql) }}
     {%- set sql = get_select_subquery(sql) %}
+    {{ comment(model.get('description')) }}
     {{ properties(_properties) }}
   ;
 
@@ -112,6 +118,7 @@
   {%- else %}
 
     create table {{ relation }}
+      {{ comment(model.get('description')) }}
       {{ properties(_properties) }}
     as (
       {{ sql }}


### PR DESCRIPTION
This avoids a schema change in Iceberg when dbt does an:
```sql
comment on table sandbox.dbt_trino.rides is 'Combined table of NYC Taxi rides with the locations'
```
Because the comment is already there.

## Overview
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

## Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
