### PR TITLE
Update dbt-core to 1.6.0rc1

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230721-125806.yaml
+++ b/.changes/unreleased/Breaking Changes-20230721-125806.yaml
@@ -1,0 +1,7 @@
+kind: Breaking Changes
+body: Update dbt-core to 1.6.0rc1
+time: 2023-07-21T12:58:06.169523+02:00
+custom:
+  Author: damian3031
+  Issue: ""
+  PR: "332"

--- a/.changes/unreleased/Breaking Changes-20230724-140221.yaml
+++ b/.changes/unreleased/Breaking Changes-20230724-140221.yaml
@@ -1,0 +1,9 @@
+kind: Breaking Changes
+body: Renamed relation type 'materializedview' to 'materialized_view' to be consistent
+  with dbt-core 1.6. If you have any custom macro where you check if relation type
+  equals to 'materializedview', change it to 'materialized_view'
+time: 2023-07-24T14:02:21.439344+02:00
+custom:
+  Author: damian3031
+  Issue: ""
+  PR: "332"

--- a/dbt/adapters/trino/__version__.py
+++ b/dbt/adapters/trino/__version__.py
@@ -1,1 +1,1 @@
-version = "1.5.1"
+version = "1.6.0rc1"

--- a/dbt/adapters/trino/connections.py
+++ b/dbt/adapters/trino/connections.py
@@ -482,8 +482,6 @@ class TrinoConnectionManager(SQLConnectionManager):
             if without_comments == "":
                 continue
 
-            individual_query = self._add_query_comment(individual_query)
-
             parent = super(TrinoConnectionManager, self)
             connection, cursor = parent.add_query(
                 individual_query, auto_begin, bindings, abridge_sql_log
@@ -504,12 +502,6 @@ class TrinoConnectionManager(SQLConnectionManager):
             )
 
         return connection, cursor
-
-    def execute(self, sql, auto_begin=False, fetch=False):
-        _, cursor = self.add_query(sql, auto_begin)
-        status = self.get_response(cursor)
-        table = self.get_result_from_cursor(cursor)
-        return status, table
 
     @classmethod
     def data_type_code_to_name(cls, type_code) -> str:

--- a/dbt/include/trino/macros/adapters.sql
+++ b/dbt/include/trino/macros/adapters.sql
@@ -32,7 +32,7 @@
       t.table_catalog as database,
       t.table_name as name,
       t.table_schema as schema,
-      case when mv.name is not null then 'materializedview'
+      case when mv.name is not null then 'materialized_view'
            when t.table_type = 'BASE TABLE' then 'table'
            when t.table_type = 'VIEW' then 'view'
            else t.table_type
@@ -149,7 +149,7 @@
 
 
 {% macro trino__drop_relation(relation) -%}
-  {% set relation_type = 'materialized view' if relation.type == 'materializedview' else relation.type %}
+  {% set relation_type = relation.type|replace("_", " ") %}
   {% call statement('drop_relation', auto_begin=False) -%}
     drop {{ relation_type }} if exists {{ relation }}
   {%- endcall %}
@@ -183,7 +183,7 @@
 
 
 {% macro trino__rename_relation(from_relation, to_relation) -%}
-  {% set from_relation_type = 'materialized view' if from_relation.type == 'materializedview' else from_relation.type %}
+  {% set from_relation_type = from_relation.type|replace("_", " ") %}
   {% call statement('rename_relation') -%}
     alter {{ from_relation_type }} {{ from_relation }} rename to {{ to_relation }}
   {%- endcall %}

--- a/dbt/include/trino/macros/materializations/materialized_view.sql
+++ b/dbt/include/trino/macros/materializations/materialized_view.sql
@@ -16,7 +16,7 @@
     {{ log("No existing materialized view found, creating materialized view...", info=true) }}
     {%- set build_sql = create_materialized_view_as(target_relation) %}
 
-  {% elif full_refresh_mode or existing_relation.type != "materializedview" %}
+  {% elif full_refresh_mode or existing_relation.type != "materialized_view" %}
     {{ log("Found a " ~ existing_relation.type ~ " with same name. Dropping it...", info=true) }}
     {#-- Make sure the backup doesn't exist so we don't encounter issues with the rename below #}
     {% set backup_identifier = existing_relation.identifier ~ "__dbt_backup" %}

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-dbt-tests-adapter~=1.5.3
+dbt-tests-adapter~=1.6.0rc1
 mypy==1.4.1  # patch updates have historically introduced breaking changes
 pre-commit~=3.3
 pytest~=7.4

--- a/tests/functional/adapter/hooks/data/seed_model.sql
+++ b/tests/functional/adapter/hooks/data/seed_model.sql
@@ -11,5 +11,6 @@ create table {schema}.on_model_hook (
     target_pass      VARCHAR,
     target_threads   INTEGER,
     run_started_at   VARCHAR,
-    invocation_id    VARCHAR
+    invocation_id    VARCHAR,
+    thread_id        VARCHAR
 );

--- a/tests/functional/adapter/hooks/data/seed_run.sql
+++ b/tests/functional/adapter/hooks/data/seed_run.sql
@@ -11,5 +11,6 @@ create table {schema}.on_run_hook (
     target_pass      VARCHAR,
     target_threads   INTEGER,
     run_started_at   VARCHAR,
-    invocation_id    VARCHAR
+    invocation_id    VARCHAR,
+    thread_id        VARCHAR
 );

--- a/tests/functional/adapter/materialization/test_materialized_view.py
+++ b/tests/functional/adapter/materialization/test_materialized_view.py
@@ -18,7 +18,7 @@ class TestIcebergMaterializedViewExists:
     @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
-            "name": "materializedview",
+            "name": "materialized_view",
         }
 
     @pytest.fixture(scope="class")
@@ -37,8 +37,8 @@ select 1 a""",
 
         # check relation types
         expected = {
-            "my_table": "materializedview",
-            "my_view": "materializedview",
+            "my_table": "materialized_view",
+            "my_view": "materialized_view",
         }
         check_relation_types(project.adapter, expected)
 
@@ -176,7 +176,7 @@ class TestIcebergMaterializedViewDropAndCreate:
         return {
             "mat_view_overrides_table.sql": model_sql,
             "mat_view_overrides_view.sql": model_sql,
-            "mat_view_overrides_materializedview.sql": model_sql,
+            "mat_view_overrides_materialized_view.sql": model_sql,
         }
 
     def test_mv_overrides_relation(self, project):
@@ -184,7 +184,7 @@ class TestIcebergMaterializedViewDropAndCreate:
         project.adapter.execute("CREATE VIEW mat_view_overrides_view AS SELECT 3 c")
         project.adapter.execute("CREATE TABLE mat_view_overrides_table AS SELECT 4 d")
         project.adapter.execute(
-            "CREATE MATERIALIZED VIEW mat_view_overrides_materializedview AS SELECT 5 e"
+            "CREATE MATERIALIZED VIEW mat_view_overrides_materialized_view AS SELECT 5 e"
         )
 
         # Seed seed
@@ -197,9 +197,9 @@ class TestIcebergMaterializedViewDropAndCreate:
 
         # Check if MVs were created correctly
         expected = {
-            "mat_view_overrides_view": "materializedview",
-            "mat_view_overrides_table": "materializedview",
-            "mat_view_overrides_materializedview": "materializedview",
+            "mat_view_overrides_view": "materialized_view",
+            "mat_view_overrides_table": "materialized_view",
+            "mat_view_overrides_materialized_view": "materialized_view",
         }
         check_relation_types(project.adapter, expected)
 
@@ -209,7 +209,7 @@ class TestIcebergMaterializedViewDropAndCreate:
                 "seed",
                 "mat_view_overrides_view",
                 "mat_view_overrides_table",
-                "mat_view_overrides_materializedview",
+                "mat_view_overrides_materialized_view",
             ],
         )
 

--- a/tests/functional/adapter/test_query_comments.py
+++ b/tests/functional/adapter/test_query_comments.py
@@ -1,9 +1,4 @@
-import json
-
-import pytest
-from dbt.exceptions import DbtRuntimeError
 from dbt.tests.adapter.query_comment.test_query_comment import (
-    BaseDefaultQueryComments,
     BaseEmptyQueryComments,
     BaseMacroArgsQueryComments,
     BaseMacroInvalidQueryComments,
@@ -11,67 +6,27 @@ from dbt.tests.adapter.query_comment.test_query_comment import (
     BaseNullQueryComments,
     BaseQueryComments,
 )
-from dbt.tests.util import run_dbt_and_capture
-from dbt.version import __version__ as dbt_version
 
 
-# TODO: below tests could be simplified to just
-# pass statements, when tests in dbt.tests.adapter
-# will be fixed
-class BaseDefaultQueryCommentsTrino(BaseDefaultQueryComments):
-    def run_get_json(self, expect_pass=True):
-        res, raw_logs = run_dbt_and_capture(
-            ["--debug", "--log-format=json", "run"], expect_pass=expect_pass
-        )
-
-        # empty lists evaluate as False
-        assert len(res) > 0
-        query = res[0].adapter_response["query"]
-        return raw_logs, query
+class TestQueryCommentsTrino(BaseQueryComments):
+    pass
 
 
-class TestQueryCommentsTrino(BaseDefaultQueryCommentsTrino, BaseQueryComments):
-    def test_matches_comment(self) -> bool:
-        logs, query = self.run_get_json()
-        assert r"/* dbt\nrules! */\n" in logs
-        assert query.startswith("/* dbt\nrules! */\n")
+class TestMacroQueryCommentsTrino(BaseMacroQueryComments):
+    pass
 
 
-class TestMacroQueryCommentsTrino(BaseDefaultQueryCommentsTrino, BaseMacroQueryComments):
-    def test_matches_comment(self) -> bool:
-        logs, query = self.run_get_json()
-        assert r"/* dbt macros\nare pretty cool */\n" in logs
-        assert query.startswith("/* dbt macros\nare pretty cool */\n")
-
-
-class TestMacroArgsQueryCommentsTrino(BaseDefaultQueryCommentsTrino, BaseMacroArgsQueryComments):
-    def test_matches_comment(self) -> bool:
-        logs, query = self.run_get_json()
-        expected_dct = {
-            "app": "dbt++",
-            "dbt_version": dbt_version,
-            "macro_version": "0.1.0",
-            "message": "blah: default",
-        }
-        expected = "/* {} */\n".format(json.dumps(expected_dct, sort_keys=True))
-        assert expected in query
+class TestMacroArgsQueryCommentsTrino(BaseMacroArgsQueryComments):
+    pass
 
 
 class TestMacroInvalidQueryCommentsTrino(BaseMacroInvalidQueryComments):
-    def test_run_assert_comments(self):
-        with pytest.raises(DbtRuntimeError):
-            self.run_get_json(expect_pass=False)
+    pass
 
 
-class TestNullQueryCommentsTrino(BaseDefaultQueryCommentsTrino, BaseNullQueryComments):
-    def test_matches_comment(self) -> bool:
-        logs, query = self.run_get_json()
-        assert "/*" not in logs or "*/" not in logs
-        assert not query.startswith("/*")
+class TestNullQueryCommentsTrino(BaseNullQueryComments):
+    pass
 
 
-class TestEmptyQueryCommentsTrino(BaseDefaultQueryCommentsTrino, BaseEmptyQueryComments):
-    def test_matches_comment(self) -> bool:
-        logs, query = self.run_get_json()
-        assert "/*" not in logs or "*/" not in logs
-        assert not query.startswith("/*")
+class TestEmptyQueryCommentsTrino(BaseEmptyQueryComments):
+    pass


### PR DESCRIPTION
- Update dbt-core and dbt-tests-adapter version to 1.6.0rc1
- Remove 'execute' method from TrinoConnectionManager, as implementation in SQLConnectionManager is sufficient, and new parameter was added there
- Remove redundant addition of query comments in 'add_query' method, as it is handled in 'execute' method in SQLConnectionManager class
- Revert "Fix tests for query comments." (commit a8309e92cb099b0245586a929059b71e3a731c1b)
- rename relation type 'materializedview' to 'materialized_view'
- adjust hooks tests