### PR TITLE
Only set the comment when persist_docs.relation is set

### DIFF
--- a/.changes/unreleased/Fixes-20230810-233738.yaml
+++ b/.changes/unreleased/Fixes-20230810-233738.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Only set the comment when persist_docs.relation is set
+time: 2023-08-10T23:37:38.828664+02:00
+custom:
+  Author: Fokko
+  Issue: "317"
+  PR: "343"

--- a/dbt/include/trino/macros/adapters.sql
+++ b/dbt/include/trino/macros/adapters.sql
@@ -89,8 +89,12 @@
 {%- endmacro -%}
 
 {% macro comment(comment) %}
-  {%- if comment is not none and comment|length > 0 -%}
-      comment '{{ comment | replace("'", "''") }}'
+  {%- set persist_docs = model['config'].get('persist_docs') -%}
+  {%- if persist_docs -%}
+    {%- set persist_relation = persist_docs.get('relation') -%}
+    {%- if persist_relation and comment is not none and comment|length > 0 -%}
+        comment '{{ comment | replace("'", "''") }}'
+    {%- endif -%}
   {%- endif -%}
 {%- endmacro -%}
 


### PR DESCRIPTION
## Overview
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

I accidentally changed default behavior in https://github.com/starburstdata/dbt-trino/pull/317

Resolves #343

Checked that it only sets the comment when:

```json
{{ config(
    ...
    persist_docs={"relation": true}
) }}
```

And with the following configuration it won't set the comment:

```json
{{ config(
    ...
    persist_docs={"relation": false}
) }}
```

```json
{{ config(
    ...
) }}
```


## Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] `README.md` updated and added information about my change
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
