### PR TITLE
Fix materialized_views filters when listing relations

### DIFF
--- a/.changes/unreleased/Fixes-20230927-124454.yaml
+++ b/.changes/unreleased/Fixes-20230927-124454.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix materialized_views filters when listing relations
+time: 2023-09-27T12:44:54.858517+02:00
+custom:
+  Author: findepi
+  Issue: ""
+  PR: "353"

--- a/dbt/include/trino/macros/adapters.sql
+++ b/dbt/include/trino/macros/adapters.sql
@@ -38,11 +38,12 @@
            else t.table_type
       end as table_type
     from {{ relation.information_schema() }}.tables t
-    left join system.metadata.materialized_views mv
+    left join (
+            select * from system.metadata.materialized_views
+            where catalog_name = '{{ relation.database | lower }}'
+              and schema_name = '{{ relation.schema | lower }}') mv
           on mv.catalog_name = t.table_catalog and mv.schema_name = t.table_schema and mv.name = t.table_name
     where t.table_schema = '{{ relation.schema | lower }}'
-          and (mv.catalog_name is null or mv.catalog_name =  '{{ relation.database | lower }}')
-          and (mv.schema_name is null or mv.schema_name =  '{{ relation.schema | lower }}')
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}


### PR DESCRIPTION
## Overview

Before the change, the `list_relations_without_caching` macro queried `system.metadata.materialized_views` with no effective filter on the catalog and schema name. In theory the Trino optimizer could figure out the effective predicate on the `system.metadata.materialized_views` table, but in practice it was not happening, and all materialized views from all catalogs where being pulled.


<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

## Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
