### PR TITLE
Adjust snapshot materialization to use view as temporary relation

### DIFF
--- a/tests/functional/adapter/test_simple_snapshot.py
+++ b/tests/functional/adapter/test_simple_snapshot.py
@@ -93,3 +93,62 @@ class TestIcebergSnapshotCheck(TrinoSnapshotCheck):
 @pytest.mark.delta
 class TestDeltaSnapshotCheck(TrinoSnapshotCheck):
     pass
+
+
+@pytest.mark.iceberg
+class TestIcebergSimpleSnapshotLocationProperty(TrinoSimpleSnapshot):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "seeds": {
+                "+column_types": {"updated_at": "timestamp(6)"},
+            },
+            "snapshots": {
+                "+properties": {
+                    "location": "'s3://datalake/TestIcebergSimpleSnapshotLocationProperty'"
+                },
+            },
+        }
+
+
+@pytest.mark.delta
+class TestDeltaSimpleSnapshotLocationProperty(TrinoSimpleSnapshot):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "snapshots": {
+                "+properties": {
+                    "location": "'s3://datalake/TestDeltaSimpleSnapshotLocationProperty'"
+                },
+            },
+        }
+
+
+@pytest.mark.iceberg
+class TestIcebergSnapshotCheckLocationProperty(TrinoSnapshotCheck):
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"iceberg.sql": iceberg_macro_override_sql}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "snapshots": {
+                "+properties": {
+                    "location": "'s3://datalake/TestIcebergSnapshotCheckLocationProperty'"
+                },
+            },
+        }
+
+
+@pytest.mark.delta
+class TestDeltaSnapshotCheckLocationProperty(TrinoSnapshotCheck):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "snapshots": {
+                "+properties": {
+                    "location": "'s3://datalake/TestDeltaSnapshotCheckLocationProperty'"
+                },
+            },
+        }


### PR DESCRIPTION
This is a draft PR to discuss possible solution to fix https://github.com/starburstdata/dbt-trino/issues/346

In snapshot materialization, we could materialize temporary relation as a view. Thanks to that, we can avoid trying to create temporary table in the same location as original table.

We have similar solution in [incremental materialization](https://github.com/starburstdata/dbt-trino/blob/v1.6.1/dbt/include/trino/macros/materializations/incremental.sql#L1). (It was also suggested by Anders as a possible solution)

WDYT? I'm opening this PR for discussion as there are possible downsides of this solution.