### PR TITLE
Remove redundant `DISTINCT` from schema listing query

### DIFF
--- a/.changes/unreleased/Under the Hood-20230929-211758.yaml
+++ b/.changes/unreleased/Under the Hood-20230929-211758.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Remove redundant DISTINCT from schema listing query
+time: 2023-09-29T21:17:58.859993+02:00
+custom:
+  Author: findepi
+  Issue: ""
+  PR: "356"

--- a/dbt/include/trino/macros/adapters.sql
+++ b/dbt/include/trino/macros/adapters.sql
@@ -215,7 +215,7 @@
 
 {% macro trino__list_schemas(database) -%}
   {% call statement('list_schemas', fetch_result=True, auto_begin=False) %}
-    select distinct schema_name
+    select schema_name
     from {{ information_schema_name(database) }}.schemata
   {% endcall %}
   {{ return(load_result('list_schemas').table) }}


### PR DESCRIPTION
## Overview

`information_schema.schemata` has no duplicates.


<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

## Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
