### PR TITLE
Query table_comments without unrolling with UNION ALL

### DIFF
--- a/.changes/unreleased/Under the Hood-20231003-161428.yaml
+++ b/.changes/unreleased/Under the Hood-20231003-161428.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Query table_comments without unrolling with UNION ALL
+time: 2023-10-03T16:14:28.238801+02:00
+custom:
+  Author: findepi
+  Issue: ""
+  PR: "357"

--- a/dbt/include/trino/macros/catalog.sql
+++ b/dbt/include/trino/macros/catalog.sql
@@ -67,7 +67,6 @@
 
 
 {% macro trino__get_catalog_table_comment_schemas_sql(information_schema, schemas) -%}
-    {%- for schema in schemas %}
     select
         catalog_name as "table_database",
         schema_name as "table_schema",
@@ -79,11 +78,7 @@
         and
         schema_name != 'information_schema'
         and
-        schema_name = '{{ schema | lower }}'
-    {%- if not loop.last %}
-    union all
-    {% endif -%}
-    {%- endfor -%}
+        schema_name in ('{{ schemas | join("','") | lower }}')
 {%- endmacro %}
 
 


### PR DESCRIPTION
## Overview

`table_comments` is equally "hard" for the engine as `information_schema.columns`. Avoid optimizing the query on the `dbt` side by sending `UNION ALL` with individual schemas. Let the engine figure out the optimal strategy.


<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

## Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
