### PR TITLE
Raise explicit error if location property is specified for snapshot

### DIFF
--- a/.changes/unreleased/Under the Hood-20231206-171742.yaml
+++ b/.changes/unreleased/Under the Hood-20231206-171742.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Raise explicit error if location property is specified for snapshot
+time: 2023-12-06T17:17:42.048225+01:00
+custom:
+  Author: damian3031
+  Issue: ""
+  PR: "380"

--- a/dbt/include/trino/macros/materializations/snapshot.sql
+++ b/dbt/include/trino/macros/materializations/snapshot.sql
@@ -1,3 +1,12 @@
+{% materialization snapshot, adapter='trino' %}
+    {% if config.get('properties') %}
+        {% if config.get('properties').get('location') %}
+            {%- do exceptions.raise_compiler_error("Specifying 'location' property in snapshots is not supported.") -%}
+        {% endif %}
+    {% endif %}
+    {{ return(materialization_snapshot_default()) }}
+{% endmaterialization %}
+
 {% macro trino__snapshot_hash_arguments(args) -%}
   lower(to_hex(md5(to_utf8(concat({%- for arg in args -%}
     coalesce(cast({{ arg }} as varchar), ''){% if not loop.last %}, '|',{% endif -%}

--- a/tests/functional/adapter/materialization/test_snapshot.py
+++ b/tests/functional/adapter/materialization/test_snapshot.py
@@ -164,3 +164,26 @@ class TestDeltaSnapshotTimestampTrino(BaseTrinoSnapshotTimestamp):
             "newcolumns.csv": seeds_newcolumns_csv,
             "added.csv": seeds_added_csv,
         }
+
+
+class TestSnapshotLocationPropertyExceptionTrino(BaseSnapshotCheckCols):
+    """
+    Specifying 'location' property in snapshots is not supported.
+    """
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "snapshot_location_property_exception",
+            "snapshots": {
+                "+properties": {
+                    "location": "some_location",
+                },
+            },
+        }
+
+    def test_snapshot_check_cols(self, project):
+        results = run_dbt(["snapshot"], expect_pass=False)
+        for result in results:
+            assert result.status == "error"
+            assert "Specifying 'location' property in snapshots is not supported" in result.message


### PR DESCRIPTION
Raise explicit error if location property is specified for snapshot