### PR TITLE
Enable on_table_exists 'replace' mode tests for SEP, and on delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This repository represents a fork of the [dbt-presto](https://github.com/dbt-lab
 
 ## Compatibility
 
-This dbt plugin has been tested against `Trino` version `439`, `Starburst Enterprise` version `435-e.1` and `Starburst Galaxy`.
+This dbt plugin has been tested against `Trino` version `445`, `Starburst Enterprise` version `435-e.4` and `Starburst Galaxy`.
 
 ## Setup & Configuration
 

--- a/docker-compose-starburst.yml
+++ b/docker-compose-starburst.yml
@@ -3,7 +3,7 @@ services:
   trino:
     ports:
       - "8080:8080"
-    image: "starburstdata/starburst-enterprise:435-e.1"
+    image: "starburstdata/starburst-enterprise:435-e.4"
     volumes:
       - ./docker/starburst/etc:/etc/starburst
       - ./docker/starburst/catalog:/etc/starburst/catalog

--- a/docker-compose-trino.yml
+++ b/docker-compose-trino.yml
@@ -3,7 +3,7 @@ services:
   trino:
     ports:
       - "8080:8080"
-    image: "trinodb/trino:439"
+    image: "trinodb/trino:445"
     volumes:
       - ./docker/trino/etc:/usr/lib/trino/etc:ro
       - ./docker/trino/catalog:/etc/trino/catalog

--- a/tests/functional/adapter/materialization/test_on_table_exists.py
+++ b/tests/functional/adapter/materialization/test_on_table_exists.py
@@ -60,10 +60,7 @@ class TestOnTableExistsDrop(BaseOnTableExists):
         check_relations_equal(project.adapter, ["seed", "materialization"])
 
 
-# TODO: Enable for SEP, after support for CORTAS will be added
-@pytest.mark.skip_engine("starburst_enterprise")
-@pytest.mark.iceberg
-class TestOnTableExistsReplace(BaseOnTableExists):
+class BaseOnTableExistsReplace(BaseOnTableExists):
     """
     Testing on_table_exists = `replace` configuration for table materialization,
     using dbt seed, run and tests commands and validate data load correctness.
@@ -98,3 +95,13 @@ class TestOnTableExistsReplace(BaseOnTableExists):
 
         # check if the data was loaded correctly
         check_relations_equal(project.adapter, ["seed", "materialization"])
+
+
+@pytest.mark.iceberg
+class TestOnTableExistsReplaceIceberg(BaseOnTableExistsReplace):
+    pass
+
+
+@pytest.mark.delta
+class TestOnTableExistsReplaceDelta(BaseOnTableExistsReplace):
+    pass


### PR DESCRIPTION
- Updated Trino and SEP versions
- Enabled on_table_exists 'replace' mode tests for SEP, and on delta