### PR TITLE
Update trino__get_columns_in_relation to use information_schema.columns

### DIFF
--- a/.changes/unreleased/Under the Hood-20241105-083613.yaml
+++ b/.changes/unreleased/Under the Hood-20241105-083613.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Update trino__get_columns_in_relation to use information_schema.columns
+time: 2024-11-05T08:36:13.788945-05:00
+custom:
+  Author: posulliv
+  Issue: "443"
+  PR: "444"

--- a/dbt/include/trino/macros/adapters.sql
+++ b/dbt/include/trino/macros/adapters.sql
@@ -5,7 +5,12 @@
 
 {% macro trino__get_columns_in_relation(relation) -%}
   {%- set sql -%}
-    describe {{ relation }}
+    select column_name, data_type
+    from {{ relation.information_schema() }}.columns
+    where
+      table_catalog = '{{ relation.database | lower }}'
+      and table_schema = '{{ relation.schema | lower }}'
+      and table_name = '{{ relation.identifier  | lower}}'
   {%- endset -%}
   {%- set result = run_query(sql) -%}
 
@@ -20,7 +25,7 @@
 
   {% set columns = [] %}
   {% for row in result %}
-    {% do columns.append(api.Column.from_description(row['Column'].lower(), row['Type'])) %}
+    {% do columns.append(api.Column.from_description(row['column_name'].lower(), row['data_type'])) %}
   {% endfor %}
   {% do return(columns) %}
 {% endmacro %}


### PR DESCRIPTION
## Overview
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

We have noticed that queries against information_schema.columns are consistently faster than describe queries. Especially when using the glue catalog with an iceberg connector. For iceberg in particular, there has been particular optimizations made to speed up queries to information_schema.columns (this PR - https://github.com/trinodb/trino/pull/18315).

We've also seen this is faster for JDBC catalogs.

This PR is to query information_schema.columns for getting column information for a relation.

Resolves #443 

## Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
