### PR TITLE
Fix breaking compatibility with Python 3.8

### DIFF
--- a/.changes/unreleased/Fixes-20241126-125237.yaml
+++ b/.changes/unreleased/Fixes-20241126-125237.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix breaking compatibility with Python 3.8
+time: 2024-11-26T12:52:37.426245+01:00
+custom:
+  Author: damian3031
+  Issue: ""
+  PR: "452"

--- a/dbt/adapters/trino/impl.py
+++ b/dbt/adapters/trino/impl.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import agate
 from dbt.adapters.base.impl import AdapterConfig, ConstraintSupport
@@ -53,7 +53,7 @@ class TrinoAdapter(SQLAdapter):
         self.connections = self.ConnectionManager(config, mp_context, self.behavior)
 
     @property
-    def _behavior_flags(self) -> list[BehaviorFlag]:
+    def _behavior_flags(self) -> List[BehaviorFlag]:
         return [
             {  # type: ignore
                 "name": "require_certificate_validation",

--- a/tests/functional/adapter/hooks/test_run_hooks.py
+++ b/tests/functional/adapter/hooks/test_run_hooks.py
@@ -3,7 +3,6 @@ from dbt.tests.adapter.hooks.test_run_hooks import (
     BaseAfterRunHooks,
     BasePrePostRunHooks,
 )
-from dbt.tests.util import run_dbt
 
 
 class TestPrePostRunHooksTrino(BasePrePostRunHooks):
@@ -55,5 +54,4 @@ class TestPrePostRunHooksTrino(BasePrePostRunHooks):
 
 
 class TestAfterRunHooksTrino(BaseAfterRunHooks):
-    def test_missing_column_pre_hook(self, project):
-        run_dbt(["run"], expect_pass=False)
+    pass


### PR DESCRIPTION
Resolves https://github.com/starburstdata/dbt-trino/issues/450

1.8.4 release broke compatibility with Python 3.8.

Keep Python 3.8 compatibility in dbt-trino 1.8.

Support for Python 3.8 will be dropped in dbt-trino 1.9 release.