### PR TITLE
Fix so that file_format and table_format config values do not require…

### DIFF
--- a/.changes/unreleased/Fixes-20241206-132238.yaml
+++ b/.changes/unreleased/Fixes-20241206-132238.yaml
@@ -1,0 +1,8 @@
+kind: Fixes
+body: Fix so that file_format and table_format config values do not require wrapping
+  in single quotes
+time: 2024-12-06T13:22:38.107177+01:00
+custom:
+  Author: damian3031
+  Issue: "454"
+  PR: "455"

--- a/dbt/include/trino/macros/adapters.sql
+++ b/dbt/include/trino/macros/adapters.sql
@@ -90,10 +90,10 @@
         {% endset %}
         {% do exceptions.raise_compiler_error(msg) %}
       {%- else -%}
-        {%- do _properties.update({'format': file_format}) -%}
+        {%- do _properties.update({'format': "'" ~ file_format ~ "'"}) -%}
       {%- endif -%}
     {%- else -%}
-      {%- set _properties = {'format': file_format} -%}
+      {%- set _properties = {'format': "'" ~ file_format ~ "'"} -%}
     {%- endif -%}
   {%- endif -%}
 
@@ -105,10 +105,10 @@
         {% endset %}
         {% do exceptions.raise_compiler_error(msg) %}
       {%- else -%}
-        {%- do _properties.update({'type': table_format}) -%}
+        {%- do _properties.update({'type': "'" ~ table_format ~ "'"}) -%}
       {%- endif -%}
     {%- else -%}
-      {%- set _properties = {'type': table_format} -%}
+      {%- set _properties = {'type': "'" ~ table_format ~ "'"} -%}
     {%- endif -%}
   {%- endif -%}
 

--- a/tests/functional/adapter/test_table_properties.py
+++ b/tests/functional/adapter/test_table_properties.py
@@ -58,7 +58,7 @@ class TestFileFormatConfig(BaseTableProperties):
             "name": "properties_test",
             "models": {
                 "+materialized": "table",
-                "file_format": "'PARQUET'",
+                "file_format": "parquet",
             },
         }
 
@@ -71,7 +71,7 @@ class TestFileFormatConfig(BaseTableProperties):
         results, logs = run_dbt_and_capture(["--debug", "run"], expect_pass=True)
         assert len(results) == 1
         assert "WITH (" in logs
-        assert "format = 'PARQUET'" in logs
+        assert "format = 'parquet'" in logs
 
 
 @pytest.mark.iceberg
@@ -86,7 +86,7 @@ class TestFileFormatConfigAndFormatTablePropertyFail(BaseTableProperties):
                 "+properties": {
                     "format": "'PARQUET'",
                 },
-                "file_format": "'ORC'",
+                "file_format": "orc",
             },
         }
 
@@ -116,7 +116,7 @@ class TestTableFormatConfig(BaseTableProperties):
             "name": "properties_test",
             "models": {
                 "+materialized": "table",
-                "table_format": "'iceberg'",
+                "table_format": "iceberg",
             },
         }
 
@@ -147,7 +147,7 @@ class TestTableFormatConfigAndTypeTablePropertyFail(BaseTableProperties):
                 "+properties": {
                     "type": "'iceberg'",
                 },
-                "table_format": "'iceberg'",
+                "table_format": "iceberg",
             },
         }
 


### PR DESCRIPTION
resolves #454 

Fix so that file_format and table_format config values do not require wrapping in single quotes


