### PR TITLE
Avoid treating VARBINARY and JSON as a string types

### DIFF
--- a/.changes/unreleased/Fixes-20250325-161315.yaml
+++ b/.changes/unreleased/Fixes-20250325-161315.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Avoid treating VARBINARY and JSON as a string types
+time: 2025-03-25T16:13:15.227499+01:00
+custom:
+  Author: damian3031
+  Issue: "437"
+  PR: "475"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       - id: isort
         args: [ "--profile", "black", "--filter-files" ]
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.1.2
     hooks:
       - id: flake8
       - id: flake8

--- a/dbt/adapters/trino/column.py
+++ b/dbt/adapters/trino/column.py
@@ -27,7 +27,7 @@ class TrinoColumn(Column):
         return super().data_type
 
     def is_string(self) -> bool:
-        return self.dtype.lower() in ["varchar", "char", "varbinary", "json"]
+        return self.dtype.lower() in ["varchar", "char"]
 
     def is_float(self) -> bool:
         return self.dtype.lower() in [

--- a/tests/functional/adapter/column_types/fixtures.py
+++ b/tests/functional/adapter/column_types/fixtures.py
@@ -10,9 +10,7 @@ select
     cast(5.5 as double precision) as double_precision_col,
     cast(6.0 as decimal) as decimal_col,
     cast('7' as char) as char_col,
-    cast('8' as varchar(20)) as varchar_col,
-    cast(X'65683F' as varbinary) as varbinary_col,
-    cast('{"k1":1,"k2":23,"k3":456}' as json) as json_col
+    cast('8' as varchar(20)) as varchar_col
 """
 
 schema_yml = """
@@ -33,6 +31,4 @@ models:
             decimal_col: ['numeric', 'number']
             char_col: ['string', 'not number']
             varchar_col: ['string', 'not number']
-            varbinary_col: ['string', 'not number']
-            json_col: ['string', 'not number']
 """

--- a/tests/functional/adapter/test_concurrency.py
+++ b/tests/functional/adapter/test_concurrency.py
@@ -6,7 +6,7 @@ from dbt.tests.util import check_relations_equal, rm_file, run_dbt, write_file
 
 
 class TestConcurrencyTrino(BaseConcurrency):
-    def test_concurrency_trino(self, project):
+    def test_concurrency(self, project):
         run_dbt(["seed", "--select", "seed"])
         results = run_dbt(["run"], expect_pass=False)
         assert len(results) == 7

--- a/tests/functional/adapter/unit_testing/test_unit_testing.py
+++ b/tests/functional/adapter/unit_testing/test_unit_testing.py
@@ -6,7 +6,8 @@ from dbt.tests.adapter.unit_testing.test_invalid_input import BaseUnitTestInvali
 from dbt.tests.adapter.unit_testing.test_types import BaseUnitTestingTypes
 
 
-class TestTrinoUnitTestingTypes(BaseUnitTestingTypes):
+@pytest.mark.skip_profile("starburst_galaxy")
+class TestTrinoUnitTestingTypesTrinoStarburst(BaseUnitTestingTypes):
     @pytest.fixture
     def data_types(self):
         # sql_value, yaml_value
@@ -22,6 +23,23 @@ class TestTrinoUnitTestingTypes(BaseUnitTestingTypes):
                 """JSON '{"bar": "baz", "balance": 7.77, "active": false}'""",
                 """'{"bar": "baz", "balance": 7.77, "active": false}'""",
             ],
+        ]
+
+
+# JSON type is not supported on object storage connectors
+@pytest.mark.skip_profile("trino_starburst")
+class TestTrinoUnitTestingTypesGalaxy(BaseUnitTestingTypes):
+    @pytest.fixture
+    def data_types(self):
+        # sql_value, yaml_value
+        return [
+            ["1", "1"],
+            ["'1'", "1"],
+            ["true", "true"],
+            ["DATE '2020-01-02'", "2020-01-02"],
+            ["TIMESTAMP '2013-11-03 00:00:00'", "2013-11-03 00:00:00"],
+            ["TIMESTAMP '2013-11-03 00:00:00-0'", "2013-11-03 00:00:00-0"],
+            ["DECIMAL '1'", "1"],
         ]
 
 


### PR DESCRIPTION
resolves #437

VARBINARY and JSON should not be treated as string types.
No other dbt adapter does this.
## Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
