### PR TITLE
Fix test for default query comment append behaviour

### DIFF
--- a/.changes/unreleased/Dependencies-20250528-191726.yaml
+++ b/.changes/unreleased/Dependencies-20250528-191726.yaml
@@ -1,0 +1,7 @@
+kind: Dependencies
+body: Update dbt-adapters to 1.15.1
+time: 2025-05-28T19:17:26.738442+02:00
+custom:
+  Author: damian3031
+  Issue: ""
+  PR: "483"

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     },
     install_requires=[
         "dbt-common>=1.14.0,<2.0",
-        "dbt-adapters>=1.10.4,<2.0",
+        "dbt-adapters~=1.15.1",
         "trino~=0.331",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
         "dbt-core>=1.8.0",

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -68,7 +68,7 @@ class TestTrinoAdapter(unittest.TestCase):
 
         self.config = config_from_parts_or_dicts(project_cfg, profile_cfg)
         self.assertEqual(self.config.query_comment.comment, "dbt")
-        self.assertEqual(self.config.query_comment.append, False)
+        self.assertEqual(self.config.query_comment.append, None)
 
     @property
     def adapter(self):


### PR DESCRIPTION
Fix test for default query comment append behaviour, as default behaviour was changed in dbt-adapters 1.15.
Pin minor version of dbt-adapters, as minor updates may introduce breaking changes.

## Overview
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

## Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
