### PR TITLE
Quote column names in `add_remove_columns` macro

### DIFF
--- a/.changes/unreleased/Fixes-20250617-195259.yaml
+++ b/.changes/unreleased/Fixes-20250617-195259.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fixes behavior of adding/removing columns when column names require quoting.
+time: 2025-06-17T19:52:59.780969-07:00
+custom:
+    Author: conor-mcavoy
+    Issue: "491"
+    PR: "490"

--- a/dbt/include/trino/macros/adapters.sql
+++ b/dbt/include/trino/macros/adapters.sql
@@ -297,14 +297,14 @@
 
   {% for column in add_columns %}
     {% set sql -%}
-      alter {{ relation.type }} {{ relation }} add column {{ column.name }} {{ column.data_type }}
+      alter {{ relation.type }} {{ relation }} add column {{ adapter.quote(column.name) }} {{ column.data_type }}
     {%- endset -%}
     {% do run_query(sql) %}
   {% endfor %}
 
   {% for column in remove_columns %}
     {% set sql -%}
-      alter {{ relation.type }} {{ relation }} drop column {{ column.name }}
+      alter {{ relation.type }} {{ relation }} drop column {{ adapter.quote(column.name) }}
     {%- endset -%}
     {% do run_query(sql) %}
   {% endfor %}

--- a/tests/functional/adapter/materialization/test_incremental_schema.py
+++ b/tests/functional/adapter/materialization/test_incremental_schema.py
@@ -11,6 +11,8 @@ from tests.functional.adapter.materialization.fixtures import (
     incremental_ignore_target_sql,
     incremental_sync_all_columns_diff_data_types_sql,
     incremental_sync_all_columns_diff_data_types_target_sql,
+    incremental_sync_all_columns_quoted_sql,
+    incremental_sync_all_columns_quoted_target_sql,
     incremental_sync_all_columns_sql,
     incremental_sync_all_columns_target_sql,
     model_a_sql,
@@ -24,6 +26,8 @@ from tests.functional.adapter.materialization.fixtures import (
     select_from_incremental_ignore_target_sql,
     select_from_incremental_sync_all_columns_diff_data_types_sql,
     select_from_incremental_sync_all_columns_diff_data_types_target_sql,
+    select_from_incremental_sync_all_columns_quoted_sql,
+    select_from_incremental_sync_all_columns_quoted_target_sql,
     select_from_incremental_sync_all_columns_sql,
     select_from_incremental_sync_all_columns_target_sql,
 )
@@ -49,6 +53,8 @@ class OnSchemaChangeBase:
             "incremental_fail.sql": incremental_fail_sql,
             "incremental_sync_all_columns.sql": incremental_sync_all_columns_sql,
             "incremental_sync_all_columns_target.sql": incremental_sync_all_columns_target_sql,
+            "incremental_sync_all_columns_quoted.sql": incremental_sync_all_columns_quoted_sql,
+            "incremental_sync_all_columns_quoted_target.sql": incremental_sync_all_columns_quoted_target_sql,
             "incremental_sync_all_columns_diff_data_types.sql": incremental_sync_all_columns_diff_data_types_sql,
             "incremental_sync_all_columns_diff_data_types_target.sql": incremental_sync_all_columns_diff_data_types_target_sql,
             "schema.yml": schema_base_yml,
@@ -66,6 +72,8 @@ class OnSchemaChangeBase:
             "select_from_incremental_ignore_target.sql": select_from_incremental_ignore_target_sql,
             "select_from_incremental_sync_all_columns.sql": select_from_incremental_sync_all_columns_sql,
             "select_from_incremental_sync_all_columns_target.sql": select_from_incremental_sync_all_columns_target_sql,
+            "select_from_incremental_sync_all_columns_quoted.sql": select_from_incremental_sync_all_columns_quoted_sql,
+            "select_from_incremental_sync_all_columns_quoted_target.sql": select_from_incremental_sync_all_columns_quoted_target_sql,
             "select_from_incremental_sync_all_columns_diff_data_types.sql": select_from_incremental_sync_all_columns_diff_data_types_sql,
             "select_from_incremental_sync_all_columns_diff_data_types_target.sql": select_from_incremental_sync_all_columns_diff_data_types_target_sql,
         }
@@ -178,6 +186,24 @@ class OnSchemaChangeBase:
             project, select, exclude, expected, compare_source, compare_target
         )
 
+    def run_incremental_sync_all_columns_quoted(self, project):
+        select = "model_a incremental_sync_all_columns_quoted incremental_sync_all_columns_quoted_target"
+        compare_source = "incremental_sync_all_columns_quoted"
+        compare_target = "incremental_sync_all_columns_quoted_target"
+        exclude = None
+        expected = [
+            "select_from_a",
+            "select_from_incremental_sync_all_columns_quoted",
+            "select_from_incremental_sync_all_columns_quoted_target",
+            "unique_model_a_id",
+            "unique_incremental_sync_all_columns_quoted_id",
+            "unique_incremental_sync_all_columns_quoted_target_id",
+        ]
+        self.list_tests_and_assert(select, exclude, expected)
+        self.run_tests_and_assert(
+            project, select, exclude, expected, compare_source, compare_target
+        )
+
     def run_incremental_sync_all_columns_data_type_change(self, project):
         select = "model_a incremental_sync_all_columns_diff_data_types incremental_sync_all_columns_diff_data_types_target"
         compare_source = "incremental_sync_all_columns_diff_data_types"
@@ -211,6 +237,7 @@ class OnSchemaChangeBase:
 
     def test_run_incremental_sync_all_columns(self, project):
         self.run_incremental_sync_all_columns(project)
+        self.run_incremental_sync_all_columns_quoted(project)
 
     def test_run_incremental_sync_all_columns_data_type_change(self, project):
         self.run_incremental_sync_all_columns_data_type_change(project)


### PR DESCRIPTION
## Overview
When adding or removing columns from an incremental DBT Trino model, if the columns added/removed require quoting, the resulting SQL statement will throw a syntax error. This is because the macro `trino__alter_relation_add_remove_columns` does not wrap column names in double-quotes, like other macros do. This PR fixes that by wrapping column names with `adapter.quote()`. This functionality is already used in `trino__alter_column_type`, for example.

This PR also adds tests for this functionality. These tests also serve to test general `add_remove_columns` behavior, which today is untested as far as I can tell.

Resolves #491

## Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
