### PR TITLE
Loosen dbt-adapters pin to allow for 1.16

### DIFF
--- a/.changes/unreleased/Dependencies-20250710-163129.yaml
+++ b/.changes/unreleased/Dependencies-20250710-163129.yaml
@@ -1,0 +1,7 @@
+kind: Dependencies
+body: update dbt-adapters dependency to 1.16
+time: 2025-07-10T16:31:29.652587-07:00
+custom:
+  Author: colin-rogers-dbt
+  Issue: "493"
+  PR: "492"

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     },
     install_requires=[
         "dbt-common>=1.25.0,<2.0",
-        "dbt-adapters~=1.15.1",
+        "dbt-adapters>=1.15.1,<1.17",
         "trino~=0.331",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
         "dbt-core>=1.8.0",


### PR DESCRIPTION
## Overview
resolves: #493 
This should be relatively safe as I believe dbt-trino is compatible with dbt-adapters==1.16

## Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
