### PR TITLE
Bump minimal required version of Trino Python to 0.334

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     install_requires=[
         "dbt-common>=1.25.0,<2.0",
         "dbt-adapters>=1.16,<2.0",
-        "trino~=0.331",
+        "trino~=0.334",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
         "dbt-core>=1.8.0",
     ],


### PR DESCRIPTION
## Overview
**Does not resolve an existing issue**

Following the latest release [v1.10.2](https://github.com/starburstdata/dbt-trino/releases/tag/v1.10.2), the `connections.py` now imports elements from [Trino Client](https://github.com/trinodb/trino-python-client) inside GSSAPIAuthentication module (see [here](https://github.com/starburstdata/dbt-trino/blob/master/dbt/adapters/trino/connections.py#L232)):
```python
GSSAPIAuthentication.MUTUAL_REQUIRED
GSSAPIAuthentication.MUTUAL_OPTIONAL
GSSAPIAuthentication.MUTUAL_DISABLED
```

However, such values were only added in [Trino Client 0.334.0](https://github.com/trinodb/trino-python-client/blame/0.334.0/trino/auth.py#L123) (see [Trino Client 0.333.0](https://github.com/trinodb/trino-python-client/blame/0.333.0/trino/auth.py) for comparison)

This PR aims to update `setup.py` to reflect such change

## Checklist

- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] `README.md` updated and added information about my change
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
