### PR TITLE
add defensive get for node.config

### DIFF
--- a/.changes/unreleased/Fixes-20260715-025039.yaml
+++ b/.changes/unreleased/Fixes-20260715-025039.yaml
@@ -3,5 +3,5 @@ body: '`build_catalog_relation` no longer raises `AttributeError` for nodes whos
 time: 2026-07-15T02:50:39.9444+05:30
 custom:
     Author: ash2shukla
-    Issue: "1234"
-    PR: "1234"
+    Issue: "521"
+    PR: "519"

--- a/.changes/unreleased/Fixes-20260715-025039.yaml
+++ b/.changes/unreleased/Fixes-20260715-025039.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: '`build_catalog_relation` no longer raises `AttributeError` for nodes whose config is not mapping-like'
+time: 2026-07-15T02:50:39.9444+05:30
+custom:
+    Author: ash2shukla
+    Issue: "1234"
+    PR: "1234"

--- a/dbt/adapters/trino/catalogs/_trino_catalog_metastore.py
+++ b/dbt/adapters/trino/catalogs/_trino_catalog_metastore.py
@@ -48,10 +48,13 @@ class TrinoCatalogIntegration(CatalogIntegration):
         # Some node configs are typed, non-mapping objects (e.g. a saved-query
         # export's ExportConfig, which has no `.get`); treat those as having no
         # storage_uri rather than raising AttributeError.
-        if not model.config or not hasattr(model.config, "get"):
+        if not model.config:
+            return None
+        get = getattr(model.config, "get", None)
+        if not callable(get):
             return None
 
-        if model_storage_uri := model.config.get("storage_uri"):
+        if model_storage_uri := get("storage_uri"):
             return model_storage_uri
 
         if not self.external_volume:
@@ -60,12 +63,12 @@ class TrinoCatalogIntegration(CatalogIntegration):
         # Default dbt behavior is that if base_location_root is not specified, `_dbt` prefix is added.
         # Even if base_location_root is explicitly set to None, `_dbt` prefix is still added.
         # Allow omitting the prefix by setting omit_base_location_root to True.
-        omit_base_location_root = model.config.get("omit_base_location_root")
+        omit_base_location_root = get("omit_base_location_root")
         if omit_base_location_root:
             storage_uri = f"{self.external_volume}/{model.schema}/{model.name}"
         else:
-            prefix = model.config.get("base_location_root") or "_dbt"
+            prefix = get("base_location_root") or "_dbt"
             storage_uri = f"{self.external_volume}/{prefix}/{model.schema}/{model.name}"
-        if suffix := model.config.get("base_location_subpath"):
+        if suffix := get("base_location_subpath"):
             storage_uri = f"{storage_uri}/{suffix}"
         return storage_uri

--- a/dbt/adapters/trino/catalogs/_trino_catalog_metastore.py
+++ b/dbt/adapters/trino/catalogs/_trino_catalog_metastore.py
@@ -45,7 +45,10 @@ class TrinoCatalogIntegration(CatalogIntegration):
         )
 
     def _calculate_storage_uri(self, model: RelationConfig) -> Optional[str]:
-        if not model.config:
+        # Some node configs are typed, non-mapping objects (e.g. a saved-query
+        # export's ExportConfig, which has no `.get`); treat those as having no
+        # storage_uri rather than raising AttributeError.
+        if not model.config or not hasattr(model.config, "get"):
             return None
 
         if model_storage_uri := model.config.get("storage_uri"):

--- a/dbt/adapters/trino/parse_model.py
+++ b/dbt/adapters/trino/parse_model.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 from dbt.adapters.catalogs import CATALOG_INTEGRATION_MODEL_CONFIG_NAME  # type: ignore
 from dbt.adapters.contracts.relation import RelationConfig
@@ -6,12 +6,23 @@ from dbt.adapters.contracts.relation import RelationConfig
 from dbt.adapters.trino import constants
 
 
+def _config_get(config: Any, key: str) -> Any:
+    """Read ``key`` from a node config that may not be dict-like.
+
+    Some node configs are typed, non-mapping objects (e.g. a saved-query export's
+    ``ExportConfig``, which has no ``.get``). Return None for those rather than
+    raising AttributeError.
+    """
+    get = getattr(config, "get", None)
+    return get(key) if callable(get) else None
+
+
 def catalog_name(model: RelationConfig) -> Optional[str]:
     """Extract catalog name from model configuration"""
     if not hasattr(model, "config") or not model.config:
         return None
 
-    if catalog := model.config.get(CATALOG_INTEGRATION_MODEL_CONFIG_NAME):
+    if catalog := _config_get(model.config, CATALOG_INTEGRATION_MODEL_CONFIG_NAME):
         return catalog
 
     return constants.DEFAULT_TRINO_CATALOG.name

--- a/tests/unit/test_parse_model.py
+++ b/tests/unit/test_parse_model.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from dbt.adapters.trino import constants, parse_model
+from dbt.adapters.trino.catalogs._trino_catalog_metastore import (
+    TrinoCatalogIntegration,
+)
+
+
+@dataclass
+class _ExportLikeConfig:
+    """Mimics a typed, non-mapping node config (no ``.get``)."""
+
+    export_as: str = "table"
+    database: Optional[str] = None
+
+
+class _ExportLikeModel:
+    def __init__(self) -> None:
+        self.config = _ExportLikeConfig()
+        self.schema = "my_schema"
+        self.name = "my_export"
+
+
+def test_catalog_name_non_mapping_config_returns_default():
+    model = _ExportLikeModel()
+    # Must not raise AttributeError; falls back to the default catalog.
+    assert parse_model.catalog_name(model) == constants.DEFAULT_TRINO_CATALOG.name
+
+
+def test_calculate_storage_uri_non_mapping_config_returns_none():
+    integration = object.__new__(TrinoCatalogIntegration)
+    integration.external_volume = "s3://bucket"
+    model = _ExportLikeModel()
+    # Must not raise AttributeError; a non-mapping config has no storage_uri.
+    assert integration._calculate_storage_uri(model) is None


### PR DESCRIPTION
## Overview
Resolves #521 

Checks if `get` actually exists on the `node.config` before getting a config key's value in `build_catalog_relation`

## Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] `README.md` updated and added information about my change
- [x] I have run `changie new` to [create a changelog entry](https://github.com/starburstdata/dbt-trino/blob/master/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
